### PR TITLE
Install FindCMinpack.cmake underneath CMAKE_INSTALL_PREFIX

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -5,4 +5,4 @@ configure_file(cminpack.pc.in ${pkg_conf_file} @ONLY)
 install(FILES ${pkg_conf_file}
     DESTINATION ${CMINPACK_LIB_INSTALL_DIR}/pkgconfig/ COMPONENT pkgconfig)
 
-install(FILES FindCMinpack.cmake DESTINATION ${CMAKE_ROOT}/Modules)
+install(FILES FindCMinpack.cmake DESTINATION share/cmake/Modules)


### PR DESCRIPTION
I'm a maintainer of Homebrew, a package manager for OS X. We prefer that build scripts install all files as a child of the prefix we give to the build script. We noticed that the .cmake file is being written outside of CMAKE_INSTALL_PREFIX.

The .cmake file will still be placed in the right place after this change if cmake and cminpack have a common installation prefix.