### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 PACKAGE=cminpack
-VERSION=1.3.5
+VERSION=1.3.7-dev
 
-CC=gcc
-CFLAGS= -O3 -g -Wall -Wextra
+### Use compiler flags from environment if available, else set defaults:
+ifneq ($(origin CC), environment)
+CC = gcc
+endif
+
+ifneq ($(origin CFLAGS), environment)
+CFLAGS = -O3 -g -Wall -Wextra
+endif
 
 ### The default configuration is to compile the double precision version
 
@@ -50,7 +56,7 @@ $(LIBSUFFIX)dpmpar_.o $(LIBSUFFIX)fdjac2_.o $(LIBSUFFIX)hybrj1_.o $(LIBSUFFIX)lm
 $(LIBSUFFIX)lmpar_.o  $(LIBSUFFIX)qform_.o  $(LIBSUFFIX)r1mpyq_.o $(LIBSUFFIX)covar_.o
 
 # target dir for install
-DESTDIR=/usr/local
+DESTDIR ?= /usr/local
 #
 #  Static library target
 #

--- a/Makefile
+++ b/Makefile
@@ -96,33 +96,33 @@ checkfail:
 	$(MAKE) -C examples checkfail
 
 $(LIB): $(OBJS)
-	ar r $@ $^
+	$(AR) r $@ $^
 	ranlib $@
 
 $(LIBSUFFIX)%.o: %.c
-	${CC} ${CFLAGS} -c -o $@ $<
+	$(CC) $(CFLAGS) -c -o $@ $<
 
 install: $(LIB)
-	cp $(LIB) ${DESTDIR}/lib
-	chmod 644 ${DESTDIR}/lib/$(LIB)
-	ranlib -t ${DESTDIR}/lib/$(LIB) # might be unnecessary
-	cp minpack.h ${DESTDIR}/include
-	chmod 644 ${DESTDIR}/include/minpack.h
-	cp cminpack.h ${DESTDIR}/include
-	chmod 644 ${DESTDIR}/include/cminpack.h
+	cp $(LIB) $(DESTDIR)/lib
+	chmod 644 $(DESTDIR)/lib/$(LIB)
+	ranlib -t $(DESTDIR)/lib/$(LIB) # might be unnecessary
+	cp minpack.h $(DESTDIR)/include
+	chmod 644 $(DESTDIR)/include/minpack.h
+	cp cminpack.h $(DESTDIR)/include
+	chmod 644 $(DESTDIR)/include/cminpack.h
 
 clean:
-	rm -f $(OBJS) $(LIB)
-	make -C examples clean
-	make -C fortran clean
+	$(RM) -f $(OBJS) $(LIB)
+	$(MAKE) -C examples clean
+	$(MAKE) -C fortran clean
 
 veryclean: clean
-	rm -f *.o libcminpack*.a *.gcno *.gcda *~ #*#
-	make -C examples veryclean
-	make -C examples veryclean LIBSUFFIX=s
-	make -C examples veryclean LIBSUFFIX=h
-	make -C examples veryclean LIBSUFFIX=l
-	make -C fortran veryclean
+	$(RM) -f *.o libcminpack*.a *.gcno *.gcda *~ #*#
+	$(MAKE) -C examples veryclean
+	$(MAKE) -C examples veryclean LIBSUFFIX=s
+	$(MAKE) -C examples veryclean LIBSUFFIX=h
+	$(MAKE) -C examples veryclean LIBSUFFIX=l
+	$(MAKE) -C fortran veryclean
 
 .PHONY: dist all double lapack longdouble float half fortran cuda check checkhalf checkfail clean veryclean
 
@@ -132,4 +132,4 @@ dist:
 	mkdir $(PACKAGE)-$(VERSION)
 	env COPYFILE_DISABLE=true COPY_EXTENDED_ATTRIBUTES_DISABLE=true tar --exclude-from dist-exclude --exclude $(PACKAGE)-$(VERSION) -cf - . | (cd $(PACKAGE)-$(VERSION); tar xf -)
 	tar zcvf $(PACKAGE)-$(VERSION).tar.gz $(PACKAGE)-$(VERSION)
-	rm -rf $(PACKAGE)-$(VERSION)
+	$(RM) -rf $(PACKAGE)-$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ CFLAGS_H=$(CFLAGS) -I/opt/local/include -D__cminpack_half__
 LDADD_H=-L/opt/local/lib -lHalf
 CC_H=$(CXX)
 
+LIB  = libcminpack$(LIBSUFFIX).a
 SRCS = $(wildcard *.c)
 OBJS = $(addprefix $(LIBSUFFIX),$(SRCS:.c=.o))
 
@@ -50,7 +51,7 @@ DESTDIR ?= /usr/local
 #  Static library target
 #
 
-all: libcminpack$(LIBSUFFIX).a
+all: $(LIB)
 
 double:
 	$(MAKE) LIBSUFFIX=
@@ -94,24 +95,24 @@ checkhalf:
 checkfail:
 	$(MAKE) -C examples checkfail
 
-
-libcminpack$(LIBSUFFIX).a:  $(OBJS)
-	ar r $@ $(OBJS); ranlib $@
+$(LIB): $(OBJS)
+	ar r $@ $^
+	ranlib $@
 
 $(LIBSUFFIX)%.o: %.c
 	${CC} ${CFLAGS} -c -o $@ $<
 
-install: libcminpack$(LIBSUFFIX).a
-	cp libcminpack$(LIBSUFFIX).a ${DESTDIR}/lib
-	chmod 644 ${DESTDIR}/lib/libcminpack$(LIBSUFFIX).a
-	ranlib -t ${DESTDIR}/lib/libcminpack$(LIBSUFFIX).a # might be unnecessary
+install: $(LIB)
+	cp $(LIB) ${DESTDIR}/lib
+	chmod 644 ${DESTDIR}/lib/$(LIB)
+	ranlib -t ${DESTDIR}/lib/$(LIB) # might be unnecessary
 	cp minpack.h ${DESTDIR}/include
 	chmod 644 ${DESTDIR}/include/minpack.h
 	cp cminpack.h ${DESTDIR}/include
 	chmod 644 ${DESTDIR}/include/cminpack.h
 
 clean:
-	rm -f $(OBJS) libcminpack$(LIBSUFFIX).a
+	rm -f $(OBJS) $(LIB)
 	make -C examples clean
 	make -C fortran clean
 

--- a/Makefile
+++ b/Makefile
@@ -41,19 +41,8 @@ CFLAGS_H=$(CFLAGS) -I/opt/local/include -D__cminpack_half__
 LDADD_H=-L/opt/local/lib -lHalf
 CC_H=$(CXX)
 
-OBJS = \
-$(LIBSUFFIX)chkder.o  $(LIBSUFFIX)enorm.o   $(LIBSUFFIX)hybrd1.o  $(LIBSUFFIX)hybrj.o  \
-$(LIBSUFFIX)lmdif1.o  $(LIBSUFFIX)lmstr1.o  $(LIBSUFFIX)qrfac.o   $(LIBSUFFIX)r1updt.o \
-$(LIBSUFFIX)dogleg.o  $(LIBSUFFIX)fdjac1.o  $(LIBSUFFIX)hybrd.o   $(LIBSUFFIX)lmder1.o \
-$(LIBSUFFIX)lmdif.o   $(LIBSUFFIX)lmstr.o   $(LIBSUFFIX)qrsolv.o  $(LIBSUFFIX)rwupdt.o \
-$(LIBSUFFIX)dpmpar.o  $(LIBSUFFIX)fdjac2.o  $(LIBSUFFIX)hybrj1.o  $(LIBSUFFIX)lmder.o \
-$(LIBSUFFIX)lmpar.o   $(LIBSUFFIX)qform.o   $(LIBSUFFIX)r1mpyq.o  $(LIBSUFFIX)covar.o $(LIBSUFFIX)covar1.o \
-$(LIBSUFFIX)chkder_.o $(LIBSUFFIX)enorm_.o  $(LIBSUFFIX)hybrd1_.o $(LIBSUFFIX)hybrj_.o \
-$(LIBSUFFIX)lmdif1_.o $(LIBSUFFIX)lmstr1_.o $(LIBSUFFIX)qrfac_.o  $(LIBSUFFIX)r1updt_.o \
-$(LIBSUFFIX)dogleg_.o $(LIBSUFFIX)fdjac1_.o $(LIBSUFFIX)hybrd_.o  $(LIBSUFFIX)lmder1_.o \
-$(LIBSUFFIX)lmdif_.o  $(LIBSUFFIX)lmstr_.o  $(LIBSUFFIX)qrsolv_.o $(LIBSUFFIX)rwupdt_.o \
-$(LIBSUFFIX)dpmpar_.o $(LIBSUFFIX)fdjac2_.o $(LIBSUFFIX)hybrj1_.o $(LIBSUFFIX)lmder_.o \
-$(LIBSUFFIX)lmpar_.o  $(LIBSUFFIX)qform_.o  $(LIBSUFFIX)r1mpyq_.o $(LIBSUFFIX)covar_.o
+SRCS = $(wildcard *.c)
+OBJS = $(addprefix $(LIBSUFFIX),$(SRCS:.c=.o))
 
 # target dir for install
 DESTDIR ?= /usr/local

--- a/fortran/Makefile
+++ b/fortran/Makefile
@@ -2,40 +2,47 @@
 
 # pick up your FORTRAN compiler
 #F77=g77
-F77=gfortran
-FFLAGS=-O3
+
+ifneq ($(origin F77), environment)
+F77 = gfortran
+endif
+
+ifneq ($(origin FFLAGS), environment)
+FFLAGS = -O3
+endif
+
 # uncomment the following for FORTRAN MINPACK
 #MINPACK=-lminpack
 #F77C=$(F77)
 #F77CFLAGS=-g
 
-OBJS = \
-chkder.o  enorm.o   hybrd1.o  hybrj.o   lmdif1.o  lmstr1.o  qrfac.o   r1updt.o \
-dogleg.o  fdjac1.o  hybrd.o   lmder1.o  lmdif.o   lmstr.o   qrsolv.o  rwupdt.o \
-dpmpar.o  fdjac2.o  hybrj1.o  lmder.o   lmpar.o   qform.o   r1mpyq.o  covar.o
+LIB  = libminpack.a
+SRCS = $(wildcard *.f)
+OBJS = $(SRCS:.f=.o)
 
 # target dir for install
-DESTDIR=/usr/local
+DESTDIR ?= /usr/local
 #
 #  Static library target
 #
 .PHONY: all clean veryclean install
 
-all: libminpack.a
+all: $(LIB)
 
-libminpack.a:  $(OBJS)
-	ar r $@ $(OBJS); ranlib $@
+$(LIB): $(OBJS)
+	$(AR) r $@ $^
+	ranlib $@
 
 %.o: %.f
-	${F77} ${FFLAGS} -c -o $@ $<
+	$(F77) $(FFLAGS) -c -o $@ $<
 
-install: libminpack.a
-	cp libminpack.a ${DESTDIR}/lib
-	chmod 644 ${DESTDIR}/lib/libminpack.a
-	ranlib -t ${DESTDIR}/lib/libminpack.a # might be unnecessary
+install: $(LIB)
+	cp $(LIB) $(DESTDIR)/lib
+	chmod 644 $(DESTDIR)/lib/$(LIB)
+	ranlib -t $(DESTDIR)/lib/$(LIB) # might be unnecessary
 
 clean:
-	rm -f $(OBJS) libminpack.a
+	$(RM) -f $(OBJS) $(LIB)
 
 veryclean:
-	rm -f *.o *.gcno *.gcda *~ #*#
+	$(RM) -f *.o *.gcno *.gcda *~ #*#


### PR DESCRIPTION
Apply some cleanups to `Makefile` and `fortran/Makefile`. Allow `CC`, `CFLAGS` and `DESTDIR` to be overridden from the environment, which is useful when cross-compiling or building within a larger project. Replace library names and hard-coded file listings with variables and glob patterns.