### PR TITLE
Add project directory as public included directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ set (cminpack_hdrs
 
 add_library (cminpack ${cminpack_srcs})
 
+target_include_directories(cminpack PUBLIC ${PROJECT_SOURCE_DIR})
+
 if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
   TARGET_LINK_LIBRARIES(cminpack m)
 endif()


### PR DESCRIPTION
I've tried to use cminpack but unfortunately, I had to add the cminpack root folder before being able to compile the program.

This simple edit edit serve only to expose the root directory to whoever does a `target_link_libraries(${PROJECT} cminpack)` and thus avoid adding other `target_include_directory() `in projects that uses cminpack.