### PR TITLE
Exported include dir and CMINPACK_NO_DLL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,18 +23,6 @@ ADD_CUSTOM_TARGET (uninstall "${CMAKE_COMMAND}" -P
 enable_testing()
 
 option (BUILD_SHARED_LIBS "Build shared libraries instead of static." OFF)
-if (BUILD_SHARED_LIBS)
-  message (STATUS "Building shared libraries.")
-else ()
-  message (STATUS "Building static libraries.")
-  set(CMAKE_RELEASE_POSTFIX _s)
-  set(CMAKE_RELWITHDEBINFO_POSTFIX _s)
-  set(CMAKE_DEBUG_POSTFIX _s)
-  set(CMAKE_MINSIZEREL_POSTFIX _s)
-  if(WIN32)
-    add_definitions(-DCMINPACK_NO_DLL)
-  endif(WIN32)
-endif ()
 
 option(USE_BLAS "Compile cminpack using cblas library if possible" ON)
 
@@ -59,6 +47,21 @@ set (cminpack_hdrs
 
 add_library (cminpack ${cminpack_srcs})
 
+
+if (BUILD_SHARED_LIBS)
+  message (STATUS "Building shared libraries.")
+else (BUILD_SHARED_LIBS)
+  message (STATUS "Building static libraries.")
+  set(CMAKE_RELEASE_POSTFIX _s)
+  set(CMAKE_RELWITHDEBINFO_POSTFIX _s)
+  set(CMAKE_DEBUG_POSTFIX _s)
+  set(CMAKE_MINSIZEREL_POSTFIX _s)
+  if(WIN32)
+	target_compile_definitions(cminpack PUBLIC CMINPACK_NO_DLL)
+  endif(WIN32)
+endif (BUILD_SHARED_LIBS)
+
+target_include_directories(cminpack INTERFACE ${PROJECT_SOURCE_DIR})
 if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
   TARGET_LINK_LIBRARIES(cminpack m)
 endif()


### PR DESCRIPTION
As with the previous PR, I exported the include directory this time as an INTERFACE property.

Also, I changed add_definitions with a target_compile_definitions for the macro CMINPACK_NO_DLL. This time, I used PUBLIC, as it is needed either for building cminpack itself and either for building other projects (CMINPACK_NO_DLL it is used for defining CMINPACK_EXPORT inside cminpack.h).

Note: CMINPACK_EXPORT expand in __declspec(dllimport) if CMINPACK_NO_DLL is not defined. 
On the other hand, this CMake script will build cminpack with CMINPACK_NO_DLL defined if no preferences are specified, so possible compilation issues can arise if you're trying to integrate cminpack from a subdirectory (without install).