### PR TITLE
Add CI testing for Windows on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+version: 1.0.{build}
+image:
+- Visual Studio 2015
+build:
+  parallel: true
+environment:
+  matrix:
+    - CMAKE_CONFIG_TYPE: "Release"
+platform:
+  - x64
+init:
+  # This is needed because reference files for tests must be checked-out with CRLF EOLs
+  - git config --global core.autocrlf true
+build_script:
+  - mkdir build
+  - cd build
+  - cmake -G "Visual Studio 14 2015 Win64" -DBUILD_SHARED_LIBS:BOOL=ON ..
+  - cmake --build . --config %CMAKE_CONFIG_TYPE%
+  - set PATH=%PATH%;%CD%\%CMAKE_CONFIG_TYPE%
+test_script:
+  - ctest --output-on-failure

--- a/minpack.h
+++ b/minpack.h
@@ -296,7 +296,7 @@ void __minpack_func__(rwupdt)(const int *n, __minpack_real__ *r, const int *ldr,
              const __minpack_real__ *w, __minpack_real__ *b, __minpack_real__ *alpha, __minpack_real__ *cos, 
              __minpack_real__ *sin);
 __minpack_attr__
-void __minpack_func__(covar)(const int *n, __minpack_real__ *r, const int *ldr, 
+void MINPACK_EXPORT __minpack_func__(covar)(const int *n, __minpack_real__ *r, const int *ldr,
            const int *ipvt, const __minpack_real__ *tol, __minpack_real__ *wa);
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Note: project will need to be added to AppVeyor by admin. After that, it will show in https://ci.appveyor.com/project/devernay/cminpack

(a build example can be checked here, based on my temporary fork: https://ci.appveyor.com/project/tadeu/cminpack/builds/22282286)