### PR TITLE
CMakeLists.txt: add_library should be after postfixs are defined 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,6 @@ set (cminpack_srcs
 set (cminpack_hdrs
     cminpack.h minpack.h)
 
-add_library (cminpack ${cminpack_srcs})
-
 
 if (BUILD_SHARED_LIBS)
   message (STATUS "Building shared libraries.")
@@ -67,10 +65,13 @@ else (BUILD_SHARED_LIBS)
   if (NOT DEFINED CMAKE_MINSIZEREL_POSTFIX)
     set(CMAKE_MINSIZEREL_POSTFIX _s)
   endif()
-  if(WIN32)
-	target_compile_definitions(cminpack PUBLIC CMINPACK_NO_DLL)
-  endif(WIN32)
 endif (BUILD_SHARED_LIBS)
+
+add_library (cminpack ${cminpack_srcs})
+
+if(NOT BUILD_SHARED_LIBS AND WIN32)
+	target_compile_definitions(cminpack PUBLIC CMINPACK_NO_DLL)
+endif(NOT BUILD_SHARED_LIBS AND WIN32)
 
 target_include_directories(cminpack INTERFACE ${PROJECT_SOURCE_DIR})
 if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")

--- a/cmake/CMinpackConfig.cmake
+++ b/cmake/CMinpackConfig.cmake
@@ -34,12 +34,12 @@ else(WIN32)
   find_library(CMINPACK_LIBRARY 
                NAMES cminpack_s cminpack
                HINTS ${PC_CMINPACK_LIBDIR} ${PC_CMINPACK_LIBRARY_DIRS} "${CMINPACK_ROOT}" "$ENV{CMINPACK_ROOT}"
-               PATH_SUFFIXES lib)
+               PATH_SUFFIXES lib lib64)
 
   find_library(CMINPACK_LIBRARY_DEBUG 
                NAMES cminpack-gd cminpack_s_d cminpack_d
                HINTS ${PC_CMINPACK_LIBDIR} ${PC_CMINPACK_LIBRARY_DIRS} "${CMINPACK_ROOT}" "$ENV{CMINPACK_ROOT}"
-               PATH_SUFFIXES lib)
+               PATH_SUFFIXES lib lib64)
 endif(WIN32)
 
 if(NOT CMINPACK_LIBRARY_DEBUG)

--- a/cmake/CMinpackConfig.cmake
+++ b/cmake/CMinpackConfig.cmake
@@ -34,12 +34,12 @@ else(WIN32)
   find_library(CMINPACK_LIBRARY 
                NAMES cminpack_s cminpack
                HINTS ${PC_CMINPACK_LIBDIR} ${PC_CMINPACK_LIBRARY_DIRS} "${CMINPACK_ROOT}" "$ENV{CMINPACK_ROOT}"
-               PATH_SUFFIXES lib lib64)
+               PATH_SUFFIXES lib)
 
   find_library(CMINPACK_LIBRARY_DEBUG 
                NAMES cminpack-gd cminpack_s_d cminpack_d
                HINTS ${PC_CMINPACK_LIBDIR} ${PC_CMINPACK_LIBRARY_DIRS} "${CMINPACK_ROOT}" "$ENV{CMINPACK_ROOT}"
-               PATH_SUFFIXES lib lib64)
+               PATH_SUFFIXES lib)
 endif(WIN32)
 
 if(NOT CMINPACK_LIBRARY_DEBUG)

--- a/cmake/CMinpackConfig.cmake
+++ b/cmake/CMinpackConfig.cmake
@@ -32,12 +32,12 @@ if(WIN32)
                PATH_SUFFIXES lib)
 else(WIN32)
   find_library(CMINPACK_LIBRARY 
-               NAMES cminpack
+               NAMES cminpack_s cminpack
                HINTS ${PC_CMINPACK_LIBDIR} ${PC_CMINPACK_LIBRARY_DIRS} "${CMINPACK_ROOT}" "$ENV{CMINPACK_ROOT}"
                PATH_SUFFIXES lib lib64)
 
   find_library(CMINPACK_LIBRARY_DEBUG 
-               NAMES cminpack-gd cminpack_d
+               NAMES cminpack-gd cminpack_s_d cminpack_d
                HINTS ${PC_CMINPACK_LIBDIR} ${PC_CMINPACK_LIBRARY_DIRS} "${CMINPACK_ROOT}" "$ENV{CMINPACK_ROOT}"
                PATH_SUFFIXES lib lib64)
 endif(WIN32)

--- a/cmake/CMinpackConfig.cmake
+++ b/cmake/CMinpackConfig.cmake
@@ -37,7 +37,7 @@ else(WIN32)
                PATH_SUFFIXES lib)
 
   find_library(CMINPACK_LIBRARY_DEBUG 
-               NAMES cminpack-gd cminpack
+               NAMES cminpack-gd cminpack_d
                HINTS ${PC_CMINPACK_LIBDIR} ${PC_CMINPACK_LIBRARY_DIRS} "${CMINPACK_ROOT}" "$ENV{CMINPACK_ROOT}"
                PATH_SUFFIXES lib)
 endif(WIN32)

--- a/cmake/CMinpackConfig.cmake
+++ b/cmake/CMinpackConfig.cmake
@@ -34,12 +34,12 @@ else(WIN32)
   find_library(CMINPACK_LIBRARY 
                NAMES cminpack
                HINTS ${PC_CMINPACK_LIBDIR} ${PC_CMINPACK_LIBRARY_DIRS} "${CMINPACK_ROOT}" "$ENV{CMINPACK_ROOT}"
-               PATH_SUFFIXES lib)
+               PATH_SUFFIXES lib lib64)
 
   find_library(CMINPACK_LIBRARY_DEBUG 
                NAMES cminpack-gd cminpack_d
                HINTS ${PC_CMINPACK_LIBDIR} ${PC_CMINPACK_LIBRARY_DIRS} "${CMINPACK_ROOT}" "$ENV{CMINPACK_ROOT}"
-               PATH_SUFFIXES lib)
+               PATH_SUFFIXES lib lib64)
 endif(WIN32)
 
 if(NOT CMINPACK_LIBRARY_DEBUG)

--- a/cmake/CMinpackConfig.cmake
+++ b/cmake/CMinpackConfig.cmake
@@ -26,7 +26,7 @@ if(WIN32)
                PATH_SUFFIXES lib)
 
   find_library(CMINPACK_LIBRARY_DEBUG 
-               NAMES cminpack_s-gd cminpack-gd cminpack_s cminpack
+               NAMES cminpack_s-gd cminpack-gd cminpack_s_d cminpack_d
                HINTS ${PC_CMINPACK_LIBDIR} ${PC_CMINPACK_LIBRARY_DIRS} "${CMINPACK_ROOT}" "$ENV{CMINPACK_ROOT}"
                PATHS "$ENV{PROGRAMFILES}/CMinpack" "$ENV{PROGRAMW6432}/CMinpack" 
                PATH_SUFFIXES lib)


### PR DESCRIPTION
Hi, 
I propose slight modifications to be consistent with new version of CMinPack.  Moreover, it seems that the add_library has to be set after postfix definition, otherwise, it is not considered (using Visual C++ at least).
Thank you very much for your great work on this project.
Bruno 