### PR TITLE
cmake: don't overwrite CMAKE_MODULE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif ()
 project (CMINPACK C)
 string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 
-set (CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+list (APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 include(${PROJECT_SOURCE_DIR}/cmake/cminpack_utils.cmake)
 # Set version and OS-specific settings


### PR DESCRIPTION
the user could have already set a different `CMAKE_MODULE_PATH`, this change supports this use case