### PR TITLE
Support CBLAS & LAPACK + single-precision.

### DIFF
--- a/cminpack.h
+++ b/cminpack.h
@@ -115,6 +115,8 @@ building a DLL on windows.
 
 #ifdef __cminpack_double__
 #define __cminpack_func__(func) func
+#define __cminpack_cblas__(func) cblas_d ## func
+#define __cminpack_lapack__(func) d ## func
 #endif
 
 #ifdef __cminpack_long_double__
@@ -123,6 +125,8 @@ building a DLL on windows.
 
 #ifdef __cminpack_float__
 #define __cminpack_func__(func) s ## func
+#define __cminpack_cblas__(func) cblas_s ## func
+#define __cminpack_lapack__(func) s ## func
 #endif
 
 #ifdef __cminpack_half__

--- a/cminpackP.h
+++ b/cminpackP.h
@@ -6,8 +6,8 @@
 #error "cminpackP.h in an internal cminpack header, and must be included after all other headers (including cminpack.h)"
 #endif
 
-#if (defined (USE_CBLAS) || defined (USE_LAPACK)) && !defined (__cminpack_double__)
-#error "cminpack can use cblas and lapack only in double precision mode"
+#if (defined (USE_CBLAS) || defined (USE_LAPACK)) && !defined (__cminpack_double__) && !defined (__cminpack_float__)
+#error "cminpack can use cblas and lapack only in double or single precision mode"
 #endif
 
 #ifdef USE_CBLAS
@@ -16,7 +16,7 @@
 #else
 #include <cblas.h>
 #endif
-#define __cminpack_enorm__(n,x) cblas_dnrm2(n,x,1)
+#define __cminpack_enorm__(n,x) __cminpack_cblas__(nrm2)(n,x,1)
 #else
 #define __cminpack_enorm__(n,x) __cminpack_func__(enorm)(n,x)
 #endif
@@ -28,28 +28,24 @@
 #if defined(__LP64__) /* In LP64 match sizes with the 32 bit ABI */
 typedef int 		__CLPK_integer;
 typedef int 		__CLPK_logical;
-typedef float 		__CLPK_real;
-typedef double 		__CLPK_doublereal;
 typedef __CLPK_logical 	(*__CLPK_L_fp)();
 typedef int 		__CLPK_ftnlen;
 #else
 typedef long int 	__CLPK_integer;
 typedef long int 	__CLPK_logical;
-typedef float 		__CLPK_real;
-typedef double 		__CLPK_doublereal;
 typedef __CLPK_logical 	(*__CLPK_L_fp)();
 typedef long int 	__CLPK_ftnlen;
 #endif
-//extern void dlartg_(double *f, double *g, double *cs, double *sn, double *r__);
-int dlartg_(__CLPK_doublereal *f, __CLPK_doublereal *g, __CLPK_doublereal *cs,
-            __CLPK_doublereal *sn, __CLPK_doublereal *r__);
-//extern void dgeqp3_(int *m, int *n, double *a, int *lda, int *jpvt, double *tau, double *work, int *lwork, int *info);
-int dgeqp3_(__CLPK_integer *m, __CLPK_integer *n, __CLPK_doublereal *a, __CLPK_integer *
-            lda, __CLPK_integer *jpvt, __CLPK_doublereal *tau, __CLPK_doublereal *work, __CLPK_integer *lwork,
-            __CLPK_integer *info);
-//extern void dgeqrf_(int *m, int *n, double *a, int *lda, double *tau, double *work, int *lwork, int *info);
-int dgeqrf_(__CLPK_integer *m, __CLPK_integer *n, __CLPK_doublereal *a, __CLPK_integer *
-            lda, __CLPK_doublereal *tau, __CLPK_doublereal *work, __CLPK_integer *lwork, __CLPK_integer *info);
+int __cminpack_lapack__(lartg_)(
+  __cminpack_real__ *f, __cminpack_real__ *g, __cminpack_real__ *cs,
+  __cminpack_real__ *sn, __cminpack_real__ *r__);
+int __cminpack_lapack__(geqp3_)(
+  __CLPK_integer *m, __CLPK_integer *n, __cminpack_real__ *a, __CLPK_integer * lda,
+  __CLPK_integer *jpvt, __cminpack_real__ *tau, __cminpack_real__ *work, __CLPK_integer *lwork,
+  __CLPK_integer *info);
+int __cminpack_lapack__(geqrf_)(
+  __CLPK_integer *m, __CLPK_integer *n, __cminpack_real__ *a, __CLPK_integer * lda,
+  __cminpack_real__ *tau, __cminpack_real__ *work, __CLPK_integer *lwork, __CLPK_integer *info);
 #endif
 #endif
 

--- a/enorm.c
+++ b/enorm.c
@@ -50,7 +50,7 @@ __cminpack_attr__
 real __cminpack_func__(enorm)(int n, const real *x)
 {
 #ifdef USE_CBLAS
-    return cblas_dnrm2(n, x, 1);
+    return __cminpack_cblas__(nrm2)(n, x, 1);
 #else /* !USE_CBLAS */
     /* System generated locals */
     real ret_val, d1;

--- a/lmpar.c
+++ b/lmpar.c
@@ -144,7 +144,7 @@ void __cminpack_func__(lmpar)(int n, real *r, int ldr,
 	}
     }
 # ifdef USE_CBLAS
-    cblas_dtrsv(CblasColMajor, CblasUpper, CblasNoTrans, CblasNonUnit, nsing, r, ldr, wa1, 1);
+    __cminpack_cblas__(trsv)(CblasColMajor, CblasUpper, CblasNoTrans, CblasNonUnit, nsing, r, ldr, wa1, 1);
 # else
     if (nsing >= 1) {
         int k;
@@ -191,7 +191,7 @@ void __cminpack_func__(lmpar)(int n, real *r, int ldr,
             wa1[j] = diag[l] * (wa2[l] / dxnorm);
         }
 #     ifdef USE_CBLAS
-        cblas_dtrsv(CblasColMajor, CblasUpper, CblasTrans, CblasNonUnit, n, r, ldr, wa1, 1);
+        __cminpack_cblas__(trsv)(CblasColMajor, CblasUpper, CblasTrans, CblasNonUnit, n, r, ldr, wa1, 1);
 #     else
         for (j = 0; j < n; ++j) {
             real sum = 0.;
@@ -213,7 +213,7 @@ void __cminpack_func__(lmpar)(int n, real *r, int ldr,
     for (j = 0; j < n; ++j) {
         real sum;
 #     ifdef USE_CBLAS
-        sum = cblas_ddot(j+1, &r[j*ldr], 1, qtb, 1);
+        sum = __cminpack_cblas__(dot)(j+1, &r[j*ldr], 1, qtb, 1);
 #     else
         int i;
         sum = 0.;
@@ -282,11 +282,11 @@ void __cminpack_func__(lmpar)(int n, real *r, int ldr,
             wa1[j] = 0.;
         }
         /* exchange the diagonal of r with sdiag */
-        cblas_dswap(n, r, ldr+1, sdiag, 1);
+        __cminpack_cblas__(swap)(n, r, ldr+1, sdiag, 1);
         /* solve lower(r).x = wa1, result id put in wa1 */
-        cblas_dtrsv(CblasColMajor, CblasLower, CblasNoTrans, CblasNonUnit, nsing, r, ldr, wa1, 1);
+        __cminpack_cblas__(trsv)(CblasColMajor, CblasLower, CblasNoTrans, CblasNonUnit, nsing, r, ldr, wa1, 1);
         /* exchange the diagonal of r with sdiag */
-        cblas_dswap( n, r, ldr+1, sdiag, 1);
+        __cminpack_cblas__(swap)(n, r, ldr+1, sdiag, 1);
 #     else /* !USE_CBLAS */
         for (j = 0; j < n; ++j) {
             l = ipvt[j]-1;

--- a/qrfac.c
+++ b/qrfac.c
@@ -19,12 +19,12 @@ void __cminpack_func__(qrfac)(int m, int n, real *a, int
     __CLPK_integer *jpvt;
 
     int i, j, k;
-    double t;
-    double* tau = wa;
+    real t;
+    real* tau = wa;
     const __CLPK_integer ltau = m > n ? n : m;
     __CLPK_integer lwork = -1;
     __CLPK_integer info = 0;
-    double* work;
+    real* work;
 
     if (pivot) {
         assert( lipvt >= n );
@@ -41,11 +41,11 @@ void __cminpack_func__(qrfac)(int m, int n, real *a, int
     /* query optimal size of work */
     lwork = -1;
     if (pivot) {
-        dgeqp3_(&m_,&n_,a,&lda_,jpvt,tau,tau,&lwork,&info);
+        __cminpack_lapack__(geqp3_)(&m_,&n_,a,&lda_,jpvt,tau,tau,&lwork,&info);
         lwork = (int)tau[0];
         assert( lwork >= 3*n+1  );
     } else {
-        dgeqrf_(&m_,&n_,a,&lda_,tau,tau,&lwork,&info);
+        __cminpack_lapack__(geqrf_)(&m_,&n_,a,&lda_,tau,tau,&lwork,&info);
         lwork = (int)tau[0];
         assert( lwork >= 1 && lwork >= n );
     }
@@ -53,7 +53,7 @@ void __cminpack_func__(qrfac)(int m, int n, real *a, int
     assert( info == 0 );
     
     /* alloc work area */
-    work = (double *)malloc(sizeof(double)*lwork);
+    work = (real *)malloc(sizeof(real)*lwork);
     assert(work != NULL);
     
     /* set acnorm first (from the doc of qrfac, acnorm may point to the same area as rdiag) */
@@ -65,14 +65,14 @@ void __cminpack_func__(qrfac)(int m, int n, real *a, int
     
     /* QR decomposition */
     if (pivot) {
-        dgeqp3_(&m_,&n_,a,&lda_,jpvt,tau,work,&lwork,&info);
+        __cminpack_lapack__(geqp3_)(&m_,&n_,a,&lda_,jpvt,tau,work,&lwork,&info);
     } else {
-        dgeqrf_(&m_,&n_,a,&lda_,tau,work,&lwork,&info);
+        __cminpack_lapack__(geqrf_)(&m_,&n_,a,&lda_,tau,work,&lwork,&info);
     }
     assert(info == 0);
     
     /* set rdiag, before the diagonal is replaced */
-    memset(rdiag, 0, sizeof(double)*n);
+    memset(rdiag, 0, sizeof(real)*n);
     for(i=0 ; i<n ; ++i) {
         rdiag[i] = a[i*lda+i];
     }

--- a/qrsolv.c
+++ b/qrsolv.c
@@ -133,7 +133,7 @@ void __cminpack_func__(qrsolv)(int n, real *r, int ldr,
 
                 if (sdiag[k] != 0.) {
 #                 ifdef USE_LAPACK
-                    dlartg_( &r[k + k * ldr], &sdiag[k], &cos, &sin, &temp );
+                    __cminpack_lapack__(lartg_)( &r[k + k * ldr], &sdiag[k], &cos, &sin, &temp );
 #                 else /* !USE_LAPACK */
                     if (fabs(r[k + k * ldr]) < fabs(sdiag[k])) {
                         real cotan;
@@ -157,7 +157,7 @@ void __cminpack_func__(qrsolv)(int n, real *r, int ldr,
 
 /*           accumulate the tranformation in the row of s. */
 #                 ifdef USE_CBLAS
-                    cblas_drot( n-k, &r[k + k * ldr], 1, &sdiag[k], 1, cos, sin );
+                    __cminpack_cblas__(rot)( n-k, &r[k + k * ldr], 1, &sdiag[k], 1, cos, sin );
 #                 else /* !USE_CBLAS */
                     r[k + k * ldr] = cos * r[k + k * ldr] + sin * sdiag[k];
                     if (n > k+1) {


### PR DESCRIPTION
This switches all calls to cblas/lapack functions to use a `__cminpack_{cblas,lapack}__` macro to select the function with the right precision.