### PR TITLE
CMake: Disable debug mode in FindMKL

### DIFF
--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -77,7 +77,7 @@
 # Théodore PAPADOPOULO (papadop.AT.inria.fr)
 
 
-set(CMAKE_FIND_DEBUG_MODE 1)
+#set(CMAKE_FIND_DEBUG_MODE 1)
 
 # Find MKL ROOT
 find_path(MKL_ROOT_DIR NAMES include/mkl_cblas.h PATHS $ENV{MKLROOT})


### PR DESCRIPTION
else cmake is way too verbose