### PR TITLE
Improve single-precision support.

### DIFF
--- a/chkder.c
+++ b/chkder.c
@@ -2,8 +2,8 @@
 #include <math.h>
 #include "cminpackP.h"
 
-#define log10e 0.43429448190325182765
-#define factor 100.
+#define log10e ((real)0.434294481903251827651128918916605082)
+#define factor ((real)100.)
 
 /* Table of constant values */
 

--- a/chkder_.c
+++ b/chkder_.c
@@ -7,8 +7,8 @@
 #include <math.h>
 #include "minpackP.h"
 
-#define log10e 0.43429448190325182765
-#define factor 100.
+#define log10e ((real)0.434294481903251827651128918916605082)
+#define factor ((real)100.)
 
 /* Table of constant values */
 

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -77,7 +77,7 @@
 # Théodore PAPADOPOULO (papadop.AT.inria.fr)
 
 
-set(CMAKE_FIND_DEBUG_MODE 1)
+#set(CMAKE_FIND_DEBUG_MODE 1)
 
 # Find MKL ROOT
 find_path(MKL_ROOT_DIR NAMES include/mkl_cblas.h PATHS $ENV{MKLROOT})

--- a/covar.c
+++ b/covar.c
@@ -85,7 +85,7 @@ void __cminpack_func__(covar)(int n, real *r, int ldr,
 	if (fabs(r[k + k * ldr]) <= tolr) {
 	    break;
 	}
-	r[k + k * ldr] = 1. / r[k + k * ldr];
+	r[k + k * ldr] = 1 / r[k + k * ldr];
 	if (k > 0) {
             for (j = 0; j < k; ++j) {
                 // coverity[copy_paste_error]

--- a/covar1.c
+++ b/covar1.c
@@ -91,7 +91,7 @@ int __cminpack_func__(covar1)(int m, int n, real fsumsq, real *r, int ldr,
 	if (fabs(r[k + k * ldr]) <= tolr) {
 	    break;
 	}
-	r[k + k * ldr] = 1. / r[k + k * ldr];
+	r[k + k * ldr] = 1 / r[k + k * ldr];
 	if (k > 0) {
             for (j = 0; j < k; ++j) {
                 // coverity[copy_paste_error]

--- a/covar_.c
+++ b/covar_.c
@@ -109,7 +109,7 @@ void __minpack_func__(covar)(const int *n, real *r__, const int *ldr,
 	if (fabs(r__[k + k * r_dim1]) <= tolr) {
 	    goto L50;
 	}
-	r__[k + k * r_dim1] = 1. / r__[k + k * r_dim1];
+	r__[k + k * r_dim1] = 1 / r__[k + k * r_dim1];
 	km1 = k - 1;
 	if (km1 < 1) {
 	    goto L30;

--- a/dogleg.c
+++ b/dogleg.c
@@ -198,17 +198,17 @@ void __cminpack_func__(dogleg)(int n, const real *r, int lr,
             d4 = sgnorm / delta;
             temp = temp - delta / qnorm * (d1 * d1)
                    + sqrt(d2 * d2
-                          + (1. - d3 * d3) * (1. - d4 * d4));
+                          + (1 - d3 * d3) * (1 - d4 * d4));
             /* Computing 2nd power */
             d1 = sgnorm / delta;
-            alpha = delta / qnorm * (1. - d1 * d1) / temp;
+            alpha = delta / qnorm * (1 - d1 * d1) / temp;
         }
     }
 
 /*     form appropriate convex combination of the gauss-newton */
 /*     direction and the scaled gradient direction. */
 
-    temp = (1. - alpha) * min(sgnorm,delta);
+    temp = (1 - alpha) * min(sgnorm,delta);
     for (j = 1; j <= n; ++j) {
 	x[j] = temp * wa1[j] + alpha * x[j];
     }

--- a/dogleg_.c
+++ b/dogleg_.c
@@ -225,17 +225,17 @@ L40:
     d__3 = *delta / qnorm;
 /* Computing 2nd power */
     d__4 = sgnorm / *delta;
-    temp = temp - *delta / qnorm * (d__1 * d__1) + sqrt(d__2 * d__2 + (1. - 
-	    d__3 * d__3) * (1. - d__4 * d__4));
+    temp = temp - *delta / qnorm * (d__1 * d__1) + sqrt(d__2 * d__2 + (1 - 
+	    d__3 * d__3) * (1 - d__4 * d__4));
 /* Computing 2nd power */
     d__1 = sgnorm / *delta;
-    alpha = *delta / qnorm * (1. - d__1 * d__1) / temp;
+    alpha = *delta / qnorm * (1 - d__1 * d__1) / temp;
 L120:
 
 /*     form appropriate convex combination of the gauss-newton */
 /*     direction and the scaled gradient direction. */
 
-    temp = (1. - alpha) * min(sgnorm,*delta);
+    temp = (1 - alpha) * min(sgnorm,*delta);
     i__1 = *n;
     for (j = 1; j <= i__1; ++j) {
 	x[j] = temp * wa1[j] + alpha * x[j];

--- a/enorm.c
+++ b/enorm.c
@@ -110,7 +110,7 @@ real __cminpack_func__(enorm)(int n, const real *x)
             if (xabs > x1max) {
                 /* Computing 2nd power */
                 d1 = x1max / xabs;
-                s1 = 1. + s1 * (d1 * d1);
+                s1 = 1 + s1 * (d1 * d1);
                 x1max = xabs;
             } else {
                 /* Computing 2nd power */
@@ -122,7 +122,7 @@ real __cminpack_func__(enorm)(int n, const real *x)
             if (xabs > x3max) {
                 /* Computing 2nd power */
                 d1 = x3max / xabs;
-                s3 = 1. + s3 * (d1 * d1);
+                s3 = 1 + s3 * (d1 * d1);
                 x3max = xabs;
             } else if (xabs != 0.) {
                 /* Computing 2nd power */
@@ -142,7 +142,7 @@ real __cminpack_func__(enorm)(int n, const real *x)
         ret_val = x1max * sqrt(s1 + (s2 / x1max) / x1max);
     } else if (s2 != 0.) {
         if (s2 >= x3max) {
-            ret_val = sqrt(s2 * (1. + (x3max / s2) * (x3max * s3)));
+            ret_val = sqrt(s2 * (1 + (x3max / s2) * (x3max * s3)));
         } else {
             ret_val = sqrt(x3max * ((s2 / x3max) + (x3max * s3)));
         }

--- a/enorm_.c
+++ b/enorm_.c
@@ -128,7 +128,7 @@ real __minpack_func__(enorm)(const int *n, const real *x)
 	}
 /* Computing 2nd power */
 	d__1 = x1max / xabs;
-	s1 = 1. + s1 * (d__1 * d__1);
+	s1 = 1 + s1 * (d__1 * d__1);
 	x1max = xabs;
 	goto L20;
 L10:
@@ -146,7 +146,7 @@ L30:
 	}
 /* Computing 2nd power */
 	d__1 = x3max / xabs;
-	s3 = 1. + s3 * (d__1 * d__1);
+	s3 = 1 + s3 * (d__1 * d__1);
 	x3max = xabs;
 	goto L50;
 L40:
@@ -182,7 +182,7 @@ L100:
 	goto L110;
     }
     if (s2 >= x3max) {
-	ret_val = sqrt(s2 * (1. + x3max / s2 * (x3max * s3)));
+	ret_val = sqrt(s2 * (1 + x3max / s2 * (x3max * s3)));
     } else {
 	ret_val = sqrt(x3max * (s2 / x3max + x3max * s3));
     }

--- a/hybrd.c
+++ b/hybrd.c
@@ -17,8 +17,8 @@ int __cminpack_func__(hybrd)(__cminpack_decl_fcn_nn__ void *p, int n, real *x, r
 {
     /* Initialized data */
 
-#define p1 .1
-#define p5 .5
+#define p1 ((real).1)
+#define p5 ((real).5)
 #define p001 .001
 #define p0001 1e-4
 
@@ -408,7 +408,7 @@ int __cminpack_func__(hybrd)(__cminpack_decl_fcn_nn__ void *p, int n, real *x, r
             if (fnorm1 < fnorm) {
                 /* Computing 2nd power */
                 d1 = fnorm1 / fnorm;
-                actred = 1. - d1 * d1;
+                actred = 1 - d1 * d1;
             }
 
 /*           compute the scaled predicted reduction. */
@@ -427,7 +427,7 @@ int __cminpack_func__(hybrd)(__cminpack_decl_fcn_nn__ void *p, int n, real *x, r
             if (temp < fnorm) {
                 /* Computing 2nd power */
                 d1 = temp / fnorm;
-                prered = 1. - d1 * d1;
+                prered = 1 - d1 * d1;
             }
 
 /*           compute the ratio of the actual to the predicted */
@@ -452,7 +452,7 @@ int __cminpack_func__(hybrd)(__cminpack_decl_fcn_nn__ void *p, int n, real *x, r
                     d1 = pnorm / p5;
                     delta = max(delta,d1);
                 }
-                if (fabs(ratio - 1.) <= p1) {
+                if (fabs(ratio - 1) <= p1) {
                     delta = pnorm / p5;
                 }
             }

--- a/hybrd_.c
+++ b/hybrd_.c
@@ -22,8 +22,8 @@ void __minpack_func__(hybrd)(__minpack_decl_fcn_nn__ const int *n, real *x, real
 
     /* Initialized data */
 
-#define p1 .1
-#define p5 .5
+#define p1 ((real).1)
+#define p5 ((real).5)
 #define p001 .001
 #define p0001 1e-4
 
@@ -453,7 +453,7 @@ L190:
     if (fnorm1 < fnorm) {
 /* Computing 2nd power */
 	d__1 = fnorm1 / fnorm;
-	actred = 1. - d__1 * d__1;
+	actred = 1 - d__1 * d__1;
     }
 
 /*           compute the scaled predicted reduction. */
@@ -476,7 +476,7 @@ L190:
     if (temp < fnorm) {
 /* Computing 2nd power */
 	d__1 = temp / fnorm;
-	prered = 1. - d__1 * d__1;
+	prered = 1 - d__1 * d__1;
     }
 
 /*           compute the ratio of the actual to the predicted */
@@ -504,7 +504,7 @@ L230:
 	d__1 = delta, d__2 = pnorm / p5;
 	delta = max(d__1,d__2);
     }
-    if (fabs(ratio - 1.) <= p1) {
+    if (fabs(ratio - 1) <= p1) {
 	delta = pnorm / p5;
     }
 L240:

--- a/hybrj.c
+++ b/hybrj.c
@@ -17,8 +17,8 @@ int __cminpack_func__(hybrj)(__cminpack_decl_fcnder_nn__ void *p, int n, real *x
 {
     /* Initialized data */
 
-#define p1 .1
-#define p5 .5
+#define p1 ((real).1)
+#define p5 ((real).5)
 #define p001 .001
 #define p0001 1e-4
 
@@ -388,7 +388,7 @@ int __cminpack_func__(hybrj)(__cminpack_decl_fcnder_nn__ void *p, int n, real *x
             if (fnorm1 < fnorm) {
                 /* Computing 2nd power */
                 d1 = fnorm1 / fnorm;
-                actred = 1. - d1 * d1;
+                actred = 1 - d1 * d1;
             }
 
 /*           compute the scaled predicted reduction. */
@@ -407,7 +407,7 @@ int __cminpack_func__(hybrj)(__cminpack_decl_fcnder_nn__ void *p, int n, real *x
             if (temp < fnorm) {
                 /* Computing 2nd power */
                 d1 = temp / fnorm;
-                prered = 1. - d1 * d1;
+                prered = 1 - d1 * d1;
             }
 
 /*           compute the ratio of the actual to the predicted */
@@ -432,7 +432,7 @@ int __cminpack_func__(hybrj)(__cminpack_decl_fcnder_nn__ void *p, int n, real *x
                     d1 = pnorm / p5;
                     delta = max(delta,d1);
                 }
-                if (fabs(ratio - 1.) <= p1) {
+                if (fabs(ratio - 1) <= p1) {
                     delta = pnorm / p5;
                 }
             }

--- a/hybrj_.c
+++ b/hybrj_.c
@@ -18,8 +18,8 @@ void __minpack_func__(hybrj)(__minpack_decl_fcnder_nn__  const int *n, real *x, 
 {
     /* Initialized data */
 
-#define p1 .1
-#define p5 .5
+#define p1 ((real).1)
+#define p5 ((real).5)
 #define p001 .001
 #define p0001 1e-4
     const int c_false = FALSE_;
@@ -431,7 +431,7 @@ L190:
     if (fnorm1 < fnorm) {
 /* Computing 2nd power */
 	d__1 = fnorm1 / fnorm;
-	actred = 1. - d__1 * d__1;
+	actred = 1 - d__1 * d__1;
     }
 
 /*           compute the scaled predicted reduction. */
@@ -454,7 +454,7 @@ L190:
     if (temp < fnorm) {
 /* Computing 2nd power */
 	d__1 = temp / fnorm;
-	prered = 1. - d__1 * d__1;
+	prered = 1 - d__1 * d__1;
     }
 
 /*           compute the ratio of the actual to the predicted */
@@ -482,7 +482,7 @@ L230:
 	d__1 = delta, d__2 = pnorm / p5;
 	delta = max(d__1,d__2);
     }
-    if (fabs(ratio - 1.) <= p1) {
+    if (fabs(ratio - 1) <= p1) {
 	delta = pnorm / p5;
     }
 L240:

--- a/lmder.c
+++ b/lmder.c
@@ -12,9 +12,9 @@ int __cminpack_func__(lmder)(__cminpack_decl_fcnder_mn__ void *p, int m, int n, 
 {
     /* Initialized data */
 
-#define p1 .1
-#define p5 .5
-#define p25 .25
+#define p1 ((real).1)
+#define p5 ((real).5)
+#define p25 ((real).25)
 #define p75 .75
 #define p0001 1e-4
 
@@ -401,7 +401,7 @@ int __cminpack_func__(lmder)(__cminpack_decl_fcnder_mn__ void *p, int m, int n, 
             if (p1 * fnorm1 < fnorm) {
                 /* Computing 2nd power */
                 d1 = fnorm1 / fnorm;
-                actred = 1. - d1 * d1;
+                actred = 1 - d1 * d1;
             }
 
 /*           compute the scaled predicted reduction and */

--- a/lmder_.c
+++ b/lmder_.c
@@ -23,9 +23,9 @@ void __minpack_func__(lmder)(__minpack_decl_fcnder_mn__ const int *m, const int 
 
     /* Initialized data */
 
-#define p1 .1
-#define p5 .5
-#define p25 .25
+#define p1 ((real).1)
+#define p5 ((real).5)
+#define p25 ((real).25)
 #define p75 .75
 #define p0001 1e-4
 
@@ -469,7 +469,7 @@ L200:
     if (p1 * fnorm1 < fnorm) {
 /* Computing 2nd power */
 	d__1 = fnorm1 / fnorm;
-	actred = 1. - d__1 * d__1;
+	actred = 1 - d__1 * d__1;
     }
 
 /*           compute the scaled predicted reduction and */

--- a/lmdif.c
+++ b/lmdif.c
@@ -13,9 +13,9 @@ int __cminpack_func__(lmdif)(__cminpack_decl_fcn_mn__ void *p, int m, int n, rea
 {
     /* Initialized data */
 
-#define p1 .1
-#define p5 .5
-#define p25 .25
+#define p1 ((real).1)
+#define p5 ((real).5)
+#define p25 ((real).25)
 #define p75 .75
 #define p0001 1e-4
 
@@ -405,7 +405,7 @@ int __cminpack_func__(lmdif)(__cminpack_decl_fcn_mn__ void *p, int m, int n, rea
             if (p1 * fnorm1 < fnorm) {
                 /* Computing 2nd power */
                 d1 = fnorm1 / fnorm;
-                actred = 1. - d1 * d1;
+                actred = 1 - d1 * d1;
             }
 
 /*           compute the scaled predicted reduction and */

--- a/lmdif_.c
+++ b/lmdif_.c
@@ -24,9 +24,9 @@ void __minpack_func__(lmdif)(__minpack_decl_fcn_mn__ const int *m, const int *n,
 
     /* Initialized data */
 
-#define p1 .1
-#define p5 .5
-#define p25 .25
+#define p1 ((real).1)
+#define p5 ((real).5)
+#define p25 ((real).25)
 #define p75 .75
 #define p0001 1e-4
 
@@ -473,7 +473,7 @@ L200:
     if (p1 * fnorm1 < fnorm) {
 /* Computing 2nd power */
 	d__1 = fnorm1 / fnorm;
-	actred = 1. - d__1 * d__1;
+	actred = 1 - d__1 * d__1;
     }
 
 /*           compute the scaled predicted reduction and */

--- a/lmpar.c
+++ b/lmpar.c
@@ -15,8 +15,8 @@ void __cminpack_func__(lmpar)(int n, real *r, int ldr,
 {
     /* Initialized data */
 
-#define p1 .1
-#define p001 .001
+#define p1 ((real).1)
+#define p001 ((real).001)
 
     /* System generated locals */
     real d1, d2;

--- a/lmpar_.c
+++ b/lmpar_.c
@@ -20,8 +20,8 @@ void __minpack_func__(lmpar)(const int *n, real *r__, const int *ldr,
 
     /* Initialized data */
 
-#define p1 .1
-#define p001 .001
+#define p1 ((real).1)
+#define p001 ((real).001)
 
     /* System generated locals */
     int r_dim1, r_offset, i__1, i__2;

--- a/lmstr.c
+++ b/lmstr.c
@@ -12,9 +12,9 @@ int __cminpack_func__(lmstr)(__cminpack_decl_fcnderstr_mn__ void *p, int m, int 
 {
     /* Initialized data */
 
-#define p1 .1
-#define p5 .5
-#define p25 .25
+#define p1 ((real).1)
+#define p5 ((real).5)
+#define p25 ((real).25)
 #define p75 .75
 #define p0001 1e-4
 
@@ -419,7 +419,7 @@ int __cminpack_func__(lmstr)(__cminpack_decl_fcnderstr_mn__ void *p, int m, int 
             if (p1 * fnorm1 < fnorm) {
                 /* Computing 2nd power */
                 d1 = fnorm1 / fnorm;
-                actred = 1. - d1 * d1;
+                actred = 1 - d1 * d1;
             }
 
 /*           compute the scaled predicted reduction and */

--- a/lmstr_.c
+++ b/lmstr_.c
@@ -23,9 +23,9 @@ void __minpack_func__(lmstr)(__minpack_decl_fcnderstr_mn__ const int *m, const i
 
     /* Initialized data */
 
-#define p1 .1
-#define p5 .5
-#define p25 .25
+#define p1 ((real).1)
+#define p5 ((real).5)
+#define p25 ((real).25)
 #define p75 .75
 #define p0001 1e-4
 
@@ -495,7 +495,7 @@ L240:
     if (p1 * fnorm1 < fnorm) {
 /* Computing 2nd power */
 	d__1 = fnorm1 / fnorm;
-	actred = 1. - d__1 * d__1;
+	actred = 1 - d__1 * d__1;
     }
 
 /*           compute the scaled predicted reduction and */

--- a/minpackP.h
+++ b/minpackP.h
@@ -36,10 +36,22 @@
 #define atan(x) atanl(x)
 #define floor(x) floorl(x)
 #define ceil(x) ceill(x)
-extern long double floorl ( long double );
-extern long double ellpkl ( long double );
 #else
 #define realm real
+#ifdef __cminpack_float__
+#define fabs(x) fabsf(x)
+#define sqrt(x) sqrtf(x)
+#define log(x) logf(x)
+#define exp(x) expf(x)
+#define sin(x) sinf(x)
+#define cos(x) cosf(x)
+#define tan(x) tanf(x)
+#define asin(x) asinf(x)
+#define acos(x) acosf(x)
+#define atan(x) atanf(x)
+#define floor(x) floorf(x)
+#define ceil(x) ceilf(x)
+#endif
 #endif
 #define min(a,b) ((a) <= (b) ? (a) : (b))
 #define max(a,b) ((a) >= (b) ? (a) : (b))

--- a/qrfac.c
+++ b/qrfac.c
@@ -245,7 +245,7 @@ void __cminpack_func__(qrfac)(int m, int n, real *a, int
             for (i = j; i < m; ++i) {
                 a[i + j * lda] /= ajnorm;
             }
-            a[j + j * lda] += 1.;
+            a[j + j * lda] += 1;
 
 /*        apply the transformation to the remaining columns */
 /*        and update the norms. */
@@ -264,7 +264,7 @@ void __cminpack_func__(qrfac)(int m, int n, real *a, int
                     if (pivot && rdiag[k] != 0.) {
                         temp = a[j + k * lda] / rdiag[k];
                         /* Computing MAX */
-                        d1 = 1. - temp * temp;
+                        d1 = 1 - temp * temp;
                         rdiag[k] *= sqrt((max((real)0.,d1)));
                         /* Computing 2nd power */
                         d1 = rdiag[k] / wa[k];

--- a/qrfac_.c
+++ b/qrfac_.c
@@ -187,7 +187,7 @@ L40:
 	    a[i__ + j * a_dim1] /= ajnorm;
 /* L50: */
 	}
-	a[j + j * a_dim1] += 1.;
+	a[j + j * a_dim1] += 1;
 
 /*        apply the transformation to the remaining columns */
 /*        and update the norms. */
@@ -217,7 +217,7 @@ L40:
 /* Computing MAX */
 /* Computing 2nd power */
 	    d__3 = temp;
-	    d__1 = 0., d__2 = 1. - d__3 * d__3;
+	    d__1 = 0., d__2 = 1 - d__3 * d__3;
 	    rdiag[k] *= sqrt((max(d__1,d__2)));
 /* Computing 2nd power */
 	    d__1 = rdiag[k] / wa[k];

--- a/qrsolv.c
+++ b/qrsolv.c
@@ -9,8 +9,8 @@ void __cminpack_func__(qrsolv)(int n, real *r, int ldr,
 {
     /* Initialized data */
 
-#define p5 .5
-#define p25 .25
+#define p5 ((real).5)
+#define p25 ((real).25)
 
     /* Local variables */
     int i, j, k, l;

--- a/qrsolv_.c
+++ b/qrsolv_.c
@@ -15,8 +15,8 @@ void __minpack_func__(qrsolv)(const int *n, real *r__, const int *ldr,
 {
     /* Initialized data */
 
-#define p5 .5
-#define p25 .25
+#define p5 ((real).5)
+#define p25 ((real).25)
 
     /* System generated locals */
     int r_dim1, r_offset, i__1, i__2, i__3;

--- a/r1mpyq.c
+++ b/r1mpyq.c
@@ -85,11 +85,11 @@ void __cminpack_func__(r1mpyq)(int m, int n, real *a, int
     for (nmj = 1; nmj <= nm1; ++nmj) {
 	j = n - nmj;
 	if (fabs(v[j]) > 1.) {
-	    cos = 1. / v[j];
-	    sin = sqrt(1. - cos * cos);
+	    cos = 1 / v[j];
+	    sin = sqrt(1 - cos * cos);
 	} else {
 	    sin = v[j];
-	    cos = sqrt(1. - sin * sin);
+	    cos = sqrt(1 - sin * sin);
 	}
 	for (i = 1; i <= m; ++i) {
 	    temp = cos * a[i + j * a_dim1] - sin * a[i + n * a_dim1];
@@ -103,11 +103,11 @@ void __cminpack_func__(r1mpyq)(int m, int n, real *a, int
 
     for (j = 1; j <= nm1; ++j) {
 	if (fabs(w[j]) > 1.) {
-	    cos = 1. / w[j];
-	    sin = sqrt(1. - cos * cos);
+	    cos = 1 / w[j];
+	    sin = sqrt(1 - cos * cos);
 	} else {
 	    sin = w[j];
-	    cos = sqrt(1. - sin * sin);
+	    cos = sqrt(1 - sin * sin);
 	}
 	for (i = 1; i <= m; ++i) {
 	    temp = cos * a[i + j * a_dim1] + sin * a[i + n * a_dim1];

--- a/r1mpyq_.c
+++ b/r1mpyq_.c
@@ -89,15 +89,15 @@ void __minpack_func__(r1mpyq)(const int *m, const int *n, real *a, const int *
     for (nmj = 1; nmj <= i__1; ++nmj) {
 	j = *n - nmj;
 	if ((d__1 = v[j], abs(d__1)) > 1.) {
-	    cos__ = 1. / v[j];
+	    cos__ = 1 / v[j];
 /* Computing 2nd power */
 	    d__2 = cos__;
-	    sin__ = sqrt(1. - d__2 * d__2);
+	    sin__ = sqrt(1 - d__2 * d__2);
 	} else {
 	    sin__ = v[j];
 /* Computing 2nd power */
 	    d__2 = sin__;
-	    cos__ = sqrt(1. - d__2 * d__2);
+	    cos__ = sqrt(1 - d__2 * d__2);
 	}
 	i__2 = *m;
 	for (i__ = 1; i__ <= i__2; ++i__) {
@@ -115,15 +115,15 @@ void __minpack_func__(r1mpyq)(const int *m, const int *n, real *a, const int *
     i__1 = nm1;
     for (j = 1; j <= i__1; ++j) {
 	if ((d__1 = w[j], abs(d__1)) > 1.) {
-	    cos__ = 1. / w[j];
+	    cos__ = 1 / w[j];
 /* Computing 2nd power */
 	    d__2 = cos__;
-	    sin__ = sqrt(1. - d__2 * d__2);
+	    sin__ = sqrt(1 - d__2 * d__2);
 	} else {
 	    sin__ = w[j];
 /* Computing 2nd power */
 	    d__2 = sin__;
-	    cos__ = sqrt(1. - d__2 * d__2);
+	    cos__ = sqrt(1 - d__2 * d__2);
 	}
 	i__2 = *m;
 	for (i__ = 1; i__ <= i__2; ++i__) {

--- a/r1updt.c
+++ b/r1updt.c
@@ -13,8 +13,8 @@ void __cminpack_func__(r1updt)(int m, int n, real *s, int
 {
     /* Initialized data */
 
-#define p5 .5
-#define p25 .25
+#define p5 ((real).5)
+#define p25 ((real).25)
 
     /* Local variables */
     int i, j, l, jj, nm1;
@@ -135,7 +135,7 @@ void __cminpack_func__(r1updt)(int m, int n, real *s, int
                     cos = sin * cotan;
                     tau = 1.;
                     if (fabs(cos) * giant > 1.) {
-                        tau = 1. / cos;
+                        tau = 1 / cos;
                     }
                 } else {
                     tan = v[j] / v[n];
@@ -185,7 +185,7 @@ void __cminpack_func__(r1updt)(int m, int n, real *s, int
                     cos = sin * cotan;
                     tau = 1.;
                     if (fabs(cos) * giant > 1.) {
-                        tau = 1. / cos;
+                        tau = 1 / cos;
                     }
                 } else {
                     tan = w[j] / s[jj];

--- a/r1updt_.c
+++ b/r1updt_.c
@@ -13,8 +13,8 @@ void __minpack_func__(r1updt)(const int *m, const int *n, real *s, const int *
 {
     /* Initialized data */
 
-#define p5 .5
-#define p25 .25
+#define p5 ((real).5)
+#define p25 ((real).25)
     const int c__3 = 3;
 
     /* System generated locals */
@@ -151,7 +151,7 @@ void __minpack_func__(r1updt)(const int *m, const int *n, real *s, const int *
 	cos__ = sin__ * cotan;
 	tau = 1.;
 	if (abs(cos__) * giant > 1.) {
-	    tau = 1. / cos__;
+	    tau = 1 / cos__;
 	}
 	goto L30;
 L20:
@@ -219,7 +219,7 @@ L70:
 	cos__ = sin__ * cotan;
 	tau = 1.;
 	if (abs(cos__) * giant > 1.) {
-	    tau = 1. / cos__;
+	    tau = 1 / cos__;
 	}
 	goto L100;
 L90:

--- a/rwupdt.c
+++ b/rwupdt.c
@@ -14,8 +14,8 @@ void __cminpack_func__(rwupdt)(int n, real *r, int ldr,
 {
     /* Initialized data */
 
-#define p5 .5
-#define p25 .25
+#define p5 ((real).5)
+#define p25 ((real).25)
 
     /* System generated locals */
     int r_dim1, r_offset;

--- a/rwupdt_.c
+++ b/rwupdt_.c
@@ -15,8 +15,8 @@ void __minpack_func__(rwupdt)(const int *n, real *r__, const int *ldr,
 {
     /* Initialized data */
 
-#define p5 .5
-#define p25 .25
+#define p5 ((real).5)
+#define p25 ((real).25)
 
     /* System generated locals */
     int r_dim1, r_offset, i__1, i__2;


### PR DESCRIPTION
The first commit switches from using `math.h` to `tgmath.h`.  This means that the single precision variants will use e.g. `sqrtf` instead of casting to `double`, calling `sqrt`, and casting back to `float`.  Hopefully this should be slighly faster, although I have admittedly not performed any profiling.  This also makes the manual definition of `#define foo(x) fool(x)` for the longdouble case unnecessary.  (Instead of using `tgmath.h` I could also have use `#define foo(x) foof(x)` in the float case, but `tgmath.h` seemed completely suitable for this use case...)

I made sure that nothing was missed by compiling with gcc's `-Wconversion` option.  In the second commit I added a few more manual casts to suppress other instances of `-Wconversion`.