### PR TITLE
cmake: fix dll export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,9 @@ foreach (cminpack_lib ${cminpack_libs})
     target_compile_definitions (cminpackld PUBLIC __cminpack_long_double__)
   endif ()
 
-  if (NOT BUILD_SHARED_LIBS AND WIN32)
+  if (BUILD_SHARED_LIBS)
+    target_compile_definitions (${cminpack_lib} PRIVATE CMINPACK_DLL_EXPORTS)
+  else ()
     target_compile_definitions (${cminpack_lib} PUBLIC CMINPACK_NO_DLL)
   endif ()
 

--- a/cminpack.h
+++ b/cminpack.h
@@ -59,8 +59,8 @@ building a DLL on windows.
 #define CMINPACK_DECLSPEC_IMPORT  _Import
 #endif
 
-#if !defined(CMINPACK_NO_DLL) && (defined(__WIN32__) || defined(WIN32) || defined (_WIN32))
-#if defined(cminpack_EXPORTS) || defined(CMINPACK_EXPORTS) || defined(CMINPACK_DLL_EXPORTS)
+#if !defined(CMINPACK_NO_DLL) && defined(_WIN32)
+  #if defined(CMINPACK_DLL_EXPORTS)
     #define  CMINPACK_EXPORT CMINPACK_DECLSPEC_EXPORT
   #else
     #define  CMINPACK_EXPORT CMINPACK_DECLSPEC_IMPORT


### PR DESCRIPTION
On win32 dll were only properly exported for the double precision
variant because the automatically added cminpack_EXPORTS was the only
one take into account from cminpack.h
now we use CMINPACK_DLL_EXPORTS for all variants to fix the build