### PR TITLE
update tools path to bin for newer mkl (2020.1.217)

### DIFF
--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -95,7 +95,7 @@ else()
     set(MKL_INCLUDE_DIR ${MKL_ROOT_DIR}/include)
 
     # set arguments to call the MKL provided tool for linking
-    set(MKL_LINK_TOOL ${MKL_ROOT_DIR}/tools/mkl_link_tool)
+    set(MKL_LINK_TOOL ${MKL_ROOT_DIR}/bin/mkl_link_tool)
 
     if (WIN32)
         set(MKL_LINK_TOOL ${MKL_LINK_TOOL}.exe)


### PR DESCRIPTION
With the newer intel mkl versions the path for `tools` has changed to `bin`. I am sure a better solution can be thought of that uses the version information. This is a patch solution for now.