### PR TITLE
Remove leftover noise from VERSION/SOVERSION variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ list (APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 include (${PROJECT_SOURCE_DIR}/cmake/cminpack_utils.cmake)
 # Set version and OS-specific settings
-set (CMINPACK_VERSION 1.3.9 STRING "CMinpack version")
-set (CMINPACK_SOVERSION 1 STRING "CMinpack API version")
+set (CMINPACK_VERSION 1.3.9)
+set (CMINPACK_SOVERSION 1) # CMinpack ABI version
 DISSECT_VERSION ()
 GET_OS_INFO ()
 


### PR DESCRIPTION
Commit 56088f9bf6c2 removed the CACHE keyword from the set command, which made the trailing help text part of the variable values. This extra text was propagated to the pkgconfig file, making it malformed.

As there is no use for any help text (e.g. in CMake GUI) for a variable which can not be overridden by a user, remove the trailing text.

Fixes #55