### PR TITLE
Fixed an invalid copy of .DLL files when building with CMake on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,14 @@ endif ()
 
 foreach (cminpack_lib ${cminpack_libs})
   add_library (${cminpack_lib} ${cminpack_srcs})
+  
+  if (OS_WIN AND BUILD_SHARED_LIBS)
+    add_custom_command(
+      TARGET ${cminpack_lib} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${cminpack_lib}>  ${CMAKE_CURRENT_BINARY_DIR}/examples
+    )
+  endif ()
+
   if (${cminpack_lib} STREQUAL "cminpacks")
     target_compile_definitions (cminpacks PUBLIC __cminpack_float__)
   elseif (${cminpack_lib} STREQUAL "cminpackld")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,5 @@ build_script:
   - cd build
   - cmake -G "Visual Studio 14 2015 Win64" -DBUILD_SHARED_LIBS:BOOL=ON ..
   - cmake --build . --config %CMAKE_CONFIG_TYPE%
-  - set PATH=%PATH%;%CD%\%CMAKE_CONFIG_TYPE%
 test_script:
   - ctest --output-on-failure -C Release

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,10 +28,6 @@ if (BUILD_EXAMPLES)
       -P "${CMINPACK_SOURCE_DIR}/examples/runtest.cmake")
   endmacro(add_minpack_test)
 
-  if (WIN32 AND BUILD_SHARED_LIBS)
-    execute_process (COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/libcminpack${CMAKE_SHARED_LIBRARY_SUFFIX} ${CMAKE_CURRENT_BINARY_DIR})
-  endif ()
-
   foreach (source ${CPGM})
     add_executable (${source}_ ${source}_.c)
     target_link_libraries (${source}_ cminpack)


### PR DESCRIPTION
## What?

I have improved the CMake build generation of shared libraries on Windows by preventing an invalid copy of .DLL files to the testing directory. In the new behavior, PATH environment variable does not need to be patched after building the library for the testing phase to work.

## Why?

On the Windows platform, at the build-generation phase with CMake, there was an invalid copy of .DLL files to the testing directory, because the .DLL was not built at the time. Moreover, for the test suite to run properly in the old behavior, PATH environment variable had to be patched -- after build, and before testing -- for the test executables to pickup the built .DLL at run time.

## How?

* Added a post build event to the library [(CMakeLists.txt)](https://github.com/devernay/cminpack/compare/master...luau-project:cminpack:fix-cmake-dll-copy?expand=1#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a) copying .DLL files to the testing directory;
* Removed the invalid copy command from [examples/CMakeLists.txt](https://github.com/devernay/cminpack/compare/master...luau-project:cminpack:fix-cmake-dll-copy?expand=1#diff-940e5356fa1137e646ea135a6f68cacbfad4fe7124c3a69163468f588acf9283);
* Removed the system environtment PATH edition on [appveyor.yml](https://github.com/devernay/cminpack/compare/master...luau-project:cminpack:fix-cmake-dll-copy?expand=1#diff-92ab9a36df5d8e9f7076f2fdec59492d1ac2d9cf27ea046767a7fc4d542ef3dc).

## Testing?

* Tested with success on a local Windows 11 installation on VirtualBox employing MinGW and Visual Studio 2022 toolsets;
* Tested with success using appveyor with the modified build configuration file [(appveyor.yml)](https://github.com/devernay/cminpack/compare/master...luau-project:cminpack:fix-cmake-dll-copy?expand=1#diff-92ab9a36df5d8e9f7076f2fdec59492d1ac2d9cf27ea046767a7fc4d542ef3dc), obtaining the following appveyor logs:
  <details>
  <summary>appveyor logs</summary>
  
  ```cmd
  [00:00:00] Build started
  [00:00:00] git config --global core.autocrlf true
  [00:00:00] git clone -q --branch=fix-cmake-dll-copy https://github.com/luau-project/cminpack.git C:\projects\cminpack
  [00:00:01] git checkout -qf c1b41f76f1ab4718b8ccd3e5df06e0dfb7addf7f
  [00:00:01] mkdir build
  [00:00:01] cd build
  [00:00:01] cmake -G "Visual Studio 14 2015 Win64" -DBUILD_SHARED_LIBS:BOOL=ON ..
  [00:00:11] -- The C compiler identification is MSVC 19.0.24241.7
  [00:00:11] -- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/x86_amd64/cl.exe
  [00:00:16] -- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/x86_amd64/cl.exe -- works
  [00:00:16] -- Detecting C compiler ABI info
  [00:00:20] -- Detecting C compiler ABI info - done
  [00:00:20] -- Detecting C compile features
  [00:00:20] -- Detecting C compile features - done
  [00:00:20] -- Operating system is Windows
  [00:00:20] -- Looking for sys/types.h
  [00:00:24] -- Looking for sys/types.h - found
  [00:00:24] -- Looking for stdint.h
  [00:00:29] -- Looking for stdint.h - found
  [00:00:29] -- Looking for stddef.h
  [00:00:33] -- Looking for stddef.h - found
  [00:00:33] -- Check size of double
  [00:00:38] -- Check size of double - done
  [00:00:38] -- Check size of long double
  [00:00:42] -- Check size of long double - done
  [00:00:42] -- Building for single precision (float) and double precision (double).
  [00:00:42] -- Building shared libraries.
  [00:00:42] -- Looking for sqrt
  [00:00:47] -- Looking for sqrt - found
  [00:00:47] -- Looking for sgemm_
  [00:00:49] -- Looking for sgemm_ - not found
  [00:00:49] -- Looking for pthread.h
  [00:00:51] -- Looking for pthread.h - not found
  [00:00:51] -- Found Threads: TRUE  
  [00:00:51] -- Could NOT find BLAS (missing: BLAS_LIBRARIES) 
  [00:00:51] -- Could NOT find BLAS (missing: BLAS_LIBRARIES) 
  [00:00:51] -- Configuring done
  [00:00:52] -- Generating done
  [00:00:52] -- Build files have been written to: C:/projects/cminpack/build
  [00:00:52] cmake --build . --config %CMAKE_CONFIG_TYPE%
  [00:00:52] Microsoft (R) Build Engine version 14.0.25420.1
  [00:00:52] Copyright (C) Microsoft Corporation. All rights reserved.
  [00:00:52] 
  [00:00:54]   Checking Build System
  [00:00:54]   Building Custom Rule C:/projects/cminpack/CMakeLists.txt
  [00:00:54]   chkder.c
  [00:00:54]   enorm.c
  [00:00:54]   hybrd1.c
  [00:00:54]   hybrj.c
  [00:00:54]   lmdif1.c
  [00:00:54]   lmstr1.c
  [00:00:54]   qrfac.c
  [00:00:54]   r1updt.c
  [00:00:54]   dogleg.c
  [00:00:54]   fdjac1.c
  [00:00:54]   hybrd.c
  [00:00:54]   lmder1.c
  [00:00:54]   lmdif.c
  [00:00:54]   lmstr.c
  [00:00:54]   qrsolv.c
  [00:00:54]   rwupdt.c
  [00:00:54]   dpmpar.c
  [00:00:54]   fdjac2.c
  [00:00:54]   hybrj1.c
  [00:00:54]   lmder.c
  [00:00:54]   Generating Code...
  [00:00:56]   Compiling...
  [00:00:56]   lmpar.c
  [00:00:56]   qform.c
  [00:00:56]   r1mpyq.c
  [00:00:56]   covar.c
  [00:00:56]   covar1.c
  [00:00:56]   chkder_.c
  [00:00:56]   enorm_.c
  [00:00:56]   hybrd1_.c
  [00:00:56]   hybrj_.c
  [00:00:56]   lmdif1_.c
  [00:00:56]   lmstr1_.c
  [00:00:56]   qrfac_.c
  [00:00:56]   r1updt_.c
  [00:00:56]   dogleg_.c
  [00:00:56]   fdjac1_.c
  [00:00:56]   hybrd_.c
  [00:00:56]   lmder1_.c
  [00:00:56]   lmdif_.c
  [00:00:56]   lmstr_.c
  [00:00:56]   qrsolv_.c
  [00:00:56]   Generating Code...
  [00:00:58]   Compiling...
  [00:00:58]   rwupdt_.c
  [00:00:58]   dpmpar_.c
  [00:00:58]   fdjac2_.c
  [00:00:58]   hybrj1_.c
  [00:00:58]   lmder_.c
  [00:00:58]   lmpar_.c
  [00:00:58]   qform_.c
  [00:00:58]   r1mpyq_.c
  [00:00:58]   covar_.c
  [00:00:58]   Generating Code...
  [00:00:58]      Creating library C:/projects/cminpack/build/Release/cminpack.lib and object C:/projects/cminpack/build/Release/cminpack.exp
  [00:00:58]   cminpack.vcxproj -> C:\projects\cminpack\build\Release\cminpack.dll
  [00:01:01]   Building Custom Rule C:/projects/cminpack/CMakeLists.txt
  [00:01:01]   chkder.c
  [00:01:01]   enorm.c
  [00:01:01]   hybrd1.c
  [00:01:01]   hybrj.c
  [00:01:01]   lmdif1.c
  [00:01:01]   lmstr1.c
  [00:01:01]   qrfac.c
  [00:01:01]   r1updt.c
  [00:01:01]   dogleg.c
  [00:01:01]   fdjac1.c
  [00:01:01]   hybrd.c
  [00:01:01]   lmder1.c
  [00:01:01]   lmdif.c
  [00:01:01]   lmstr.c
  [00:01:01]   qrsolv.c
  [00:01:01]   rwupdt.c
  [00:01:01]   dpmpar.c
  [00:01:01]   fdjac2.c
  [00:01:01]   hybrj1.c
  [00:01:01]   lmder.c
  [00:01:01]   Generating Code...
  [00:01:03]   Compiling...
  [00:01:03]   lmpar.c
  [00:01:03]   qform.c
  [00:01:03]   r1mpyq.c
  [00:01:03]   covar.c
  [00:01:03]   covar1.c
  [00:01:03]   chkder_.c
  [00:01:03]   enorm_.c
  [00:01:03]   hybrd1_.c
  [00:01:03]   hybrj_.c
  [00:01:03]   lmdif1_.c
  [00:01:03]   lmstr1_.c
  [00:01:03]   qrfac_.c
  [00:01:03]   r1updt_.c
  [00:01:03]   dogleg_.c
  [00:01:03]   fdjac1_.c
  [00:01:03]   hybrd_.c
  [00:01:03]   lmder1_.c
  [00:01:03]   lmdif_.c
  [00:01:03]   lmstr_.c
  [00:01:03]   qrsolv_.c
  [00:01:03]   Generating Code...
  [00:01:05]   Compiling...
  [00:01:05]   rwupdt_.c
  [00:01:05]   dpmpar_.c
  [00:01:05]   fdjac2_.c
  [00:01:05]   hybrj1_.c
  [00:01:05]   lmder_.c
  [00:01:05]   lmpar_.c
  [00:01:05]   qform_.c
  [00:01:05]   r1mpyq_.c
  [00:01:05]   covar_.c
  [00:01:05]   Generating Code...
  [00:01:05]      Creating library C:/projects/cminpack/build/Release/cminpacks.lib and object C:/projects/cminpack/build/Release/cminpacks.exp
  [00:01:05]   cminpacks.vcxproj -> C:\projects\cminpack\build\Release\cminpacks.dll
  [00:01:08]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:08]   cmpfiles.c
  [00:01:08] C:\projects\cminpack\examples\cmpfiles.c(22): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\projects\cminpack\build\examples\cmpfiles.vcxproj]
  [00:01:08]   C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(205): note: see declaration of 'fopen'
  [00:01:08] C:\projects\cminpack\examples\cmpfiles.c(27): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\projects\cminpack\build\examples\cmpfiles.vcxproj]
  [00:01:08]   C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(205): note: see declaration of 'fopen'
  [00:01:08]   cmpfiles.vcxproj -> C:\projects\cminpack\build\examples\Release\cmpfiles.exe
  [00:01:10]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:10]   tchkder_.c
  [00:01:10]   tchkder_.vcxproj -> C:\projects\cminpack\build\examples\Release\tchkder_.exe
  [00:01:12]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:13]   tchkderc.c
  [00:01:13]   tchkderc.vcxproj -> C:\projects\cminpack\build\examples\Release\tchkderc.exe
  [00:01:15]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:15]   tfdjac2_.c
  [00:01:15]   tfdjac2_.vcxproj -> C:\projects\cminpack\build\examples\Release\tfdjac2_.exe
  [00:01:17]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:17]   tfdjac2c.c
  [00:01:18]   tfdjac2c.vcxproj -> C:\projects\cminpack\build\examples\Release\tfdjac2c.exe
  [00:01:20]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:20]   thybrd1_.c
  [00:01:20]   thybrd1_.vcxproj -> C:\projects\cminpack\build\examples\Release\thybrd1_.exe
  [00:01:22]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:22]   thybrd1c.c
  [00:01:22]   thybrd1c.vcxproj -> C:\projects\cminpack\build\examples\Release\thybrd1c.exe
  [00:01:25]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:25]   thybrd_.c
  [00:01:25]   thybrd_.vcxproj -> C:\projects\cminpack\build\examples\Release\thybrd_.exe
  [00:01:27]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:27]   thybrdc.c
  [00:01:27]   thybrdc.vcxproj -> C:\projects\cminpack\build\examples\Release\thybrdc.exe
  [00:01:30]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:30]   thybrj1_.c
  [00:01:30]   thybrj1_.vcxproj -> C:\projects\cminpack\build\examples\Release\thybrj1_.exe
  [00:01:32]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:32]   thybrj1c.c
  [00:01:32]   thybrj1c.vcxproj -> C:\projects\cminpack\build\examples\Release\thybrj1c.exe
  [00:01:35]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:35]   thybrj_.c
  [00:01:35]   thybrj_.vcxproj -> C:\projects\cminpack\build\examples\Release\thybrj_.exe
  [00:01:37]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:37]   thybrjc.c
  [00:01:37]   thybrjc.vcxproj -> C:\projects\cminpack\build\examples\Release\thybrjc.exe
  [00:01:40]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:40]   tlmder1_.c
  [00:01:40]   tlmder1_.vcxproj -> C:\projects\cminpack\build\examples\Release\tlmder1_.exe
  [00:01:42]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:42]   tlmder1c.c
  [00:01:42]   tlmder1c.vcxproj -> C:\projects\cminpack\build\examples\Release\tlmder1c.exe
  [00:01:44]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:44]   tlmder_.c
  [00:01:45]   tlmder_.vcxproj -> C:\projects\cminpack\build\examples\Release\tlmder_.exe
  [00:01:47]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:47]   tlmderc.c
  [00:01:47]   tlmderc.vcxproj -> C:\projects\cminpack\build\examples\Release\tlmderc.exe
  [00:01:49]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:49]   tlmdif1_.c
  [00:01:49]   tlmdif1_.vcxproj -> C:\projects\cminpack\build\examples\Release\tlmdif1_.exe
  [00:01:51]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:52]   tlmdif1c.c
  [00:01:52]   tlmdif1c.vcxproj -> C:\projects\cminpack\build\examples\Release\tlmdif1c.exe
  [00:01:54]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:54]   tlmdif_.c
  [00:01:54]   tlmdif_.vcxproj -> C:\projects\cminpack\build\examples\Release\tlmdif_.exe
  [00:01:56]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:56]   tlmdifc.c
  [00:01:56]   tlmdifc.vcxproj -> C:\projects\cminpack\build\examples\Release\tlmdifc.exe
  [00:01:59]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:01:59]   tlmstr1_.c
  [00:01:59]   tlmstr1_.vcxproj -> C:\projects\cminpack\build\examples\Release\tlmstr1_.exe
  [00:02:01]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:02:01]   tlmstr1c.c
  [00:02:01]   tlmstr1c.vcxproj -> C:\projects\cminpack\build\examples\Release\tlmstr1c.exe
  [00:02:04]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:02:04]   tlmstr_.c
  [00:02:04]   tlmstr_.vcxproj -> C:\projects\cminpack\build\examples\Release\tlmstr_.exe
  [00:02:06]   Building Custom Rule C:/projects/cminpack/examples/CMakeLists.txt
  [00:02:06]   tlmstrc.c
  [00:02:06]   tlmstrc.vcxproj -> C:\projects\cminpack\build\examples\Release\tlmstrc.exe
  [00:02:08]   Building Custom Rule C:/projects/cminpack/CMakeLists.txt
  [00:02:08] ctest --output-on-failure -C Release
  [00:02:09] Test project C:/projects/cminpack/build
  [00:02:09]       Start  1: tchkder_
  [00:02:09]  1/24 Test  #1: tchkder_ .........................   Passed    0.06 sec
  [00:02:09]       Start  2: tchkderc
  [00:02:09]  2/24 Test  #2: tchkderc .........................   Passed    0.03 sec
  [00:02:09]       Start  3: thybrd_
  [00:02:09]  3/24 Test  #3: thybrd_ ..........................   Passed    0.03 sec
  [00:02:09]       Start  4: thybrdc
  [00:02:09]  4/24 Test  #4: thybrdc ..........................   Passed    0.03 sec
  [00:02:09]       Start  5: thybrd1_
  [00:02:09]  5/24 Test  #5: thybrd1_ .........................   Passed    0.03 sec
  [00:02:09]       Start  6: thybrd1c
  [00:02:09]  6/24 Test  #6: thybrd1c .........................   Passed    0.04 sec
  [00:02:09]       Start  7: thybrj_
  [00:02:09]  7/24 Test  #7: thybrj_ ..........................   Passed    0.03 sec
  [00:02:09]       Start  8: thybrjc
  [00:02:09]  8/24 Test  #8: thybrjc ..........................   Passed    0.03 sec
  [00:02:09]       Start  9: thybrj1_
  [00:02:09]  9/24 Test  #9: thybrj1_ .........................   Passed    0.03 sec
  [00:02:09]       Start 10: thybrj1c
  [00:02:09] 10/24 Test #10: thybrj1c .........................   Passed    0.03 sec
  [00:02:09]       Start 11: tlmder_
  [00:02:09] 11/24 Test #11: tlmder_ ..........................   Passed    0.03 sec
  [00:02:09]       Start 12: tlmderc
  [00:02:09] 12/24 Test #12: tlmderc ..........................   Passed    0.03 sec
  [00:02:09]       Start 13: tlmder1_
  [00:02:09] 13/24 Test #13: tlmder1_ .........................   Passed    0.03 sec
  [00:02:09]       Start 14: tlmder1c
  [00:02:09] 14/24 Test #14: tlmder1c .........................   Passed    0.03 sec
  [00:02:09]       Start 15: tlmdif_
  [00:02:09] 15/24 Test #15: tlmdif_ ..........................   Passed    0.03 sec
  [00:02:09]       Start 16: tlmdifc
  [00:02:09] 16/24 Test #16: tlmdifc ..........................   Passed    0.03 sec
  [00:02:09]       Start 17: tlmdif1_
  [00:02:09] 17/24 Test #17: tlmdif1_ .........................   Passed    0.03 sec
  [00:02:09]       Start 18: tlmdif1c
  [00:02:09] 18/24 Test #18: tlmdif1c .........................   Passed    0.03 sec
  [00:02:09]       Start 19: tlmstr_
  [00:02:09] 19/24 Test #19: tlmstr_ ..........................   Passed    0.03 sec
  [00:02:09]       Start 20: tlmstrc
  [00:02:09] 20/24 Test #20: tlmstrc ..........................   Passed    0.03 sec
  [00:02:09]       Start 21: tlmstr1_
  [00:02:09] 21/24 Test #21: tlmstr1_ .........................   Passed    0.03 sec
  [00:02:09]       Start 22: tlmstr1c
  [00:02:09] 22/24 Test #22: tlmstr1c .........................   Passed    0.03 sec
  [00:02:09]       Start 23: tfdjac2_
  [00:02:09] 23/24 Test #23: tfdjac2_ .........................   Passed    0.03 sec
  [00:02:09]       Start 24: tfdjac2c
  [00:02:09] 24/24 Test #24: tfdjac2c .........................   Passed    0.03 sec
  [00:02:09] 
  [00:02:09] 100% tests passed, 0 tests failed out of 24
  [00:02:09] 
  [00:02:09] Total Test time (real) =   0.82 sec
  [00:02:10] Build success
  ```
  </details>

## Screenshots?

* Copy error removed from the build phase: ![error_at_build_generation_phase](https://github.com/devernay/cminpack/assets/18295115/fc47807e-1563-4b1e-ba61-2f833edbc66d)
* Environment system PATH variable not patched anymore: ![path_env_update_removed](https://github.com/devernay/cminpack/assets/18295115/dd3f23ab-964e-4161-be01-36c28923b0e8)
