### PR TITLE
Initial Github Actions covering latest Ubuntu and Visual Studio builds through CMake

### DIFF
--- a/.github/workflows/ubuntu-cminpack-install.yaml
+++ b/.github/workflows/ubuntu-cminpack-install.yaml
@@ -1,0 +1,33 @@
+name: Install cminpack on Ubuntu through CMake
+run-name: Build, test and install cminpack on Ubuntu through CMake
+on: [push]
+jobs:
+  cminpack-ubuntu:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        CMINPACK_BUILD_SHARED_LIBS: [ 'ON' , 'OFF' ]
+        CMINPACK_BUILD_TYPE: [ 'Release', 'Debug', 'RelWithDebInfo', 'MinSizeRel' ]
+        CMINPACK_PRECISION: [ 'd' ] # seems to be the only precision that the current tests reference work
+    env:
+      CMINPACK_BUILD_DIR: $RUNNER_TEMP/cminpack-build-shared-libs-${{ matrix.CMINPACK_BUILD_SHARED_LIBS }}-build-type-${{ matrix.CMINPACK_BUILD_TYPE }}-precision-${{ matrix.CMINPACK_PRECISION }}
+      CMINPACK_INSTALL_DIR: $RUNNER_TEMP/cminpack-install-shared-libs-${{ matrix.CMINPACK_BUILD_SHARED_LIBS }}-build-type-${{ matrix.CMINPACK_BUILD_TYPE }}-precision-${{ matrix.CMINPACK_PRECISION }}
+    steps:
+      - name: Checkout repository to cminpack directory
+        uses: actions/checkout@v4
+        with:
+          path: cminpack
+      - name: Configure cminpack build
+        run: cmake -G "Unix Makefiles" -DBUILD_SHARED_LIBS=${{ matrix.CMINPACK_BUILD_SHARED_LIBS }} -DCMAKE_BUILD_TYPE=${{ matrix.CMINPACK_BUILD_TYPE }} -DCMINPACK_PRECISION=${{ matrix.CMINPACK_PRECISION }} -DUSE_BLAS=OFF --install-prefix ${{ env.CMINPACK_INSTALL_DIR }} -S cminpack -B ${{ env.CMINPACK_BUILD_DIR }}
+      - name: Build cminpack
+        run: cmake --build ${{ env.CMINPACK_BUILD_DIR }} --config ${{ matrix.CMINPACK_BUILD_TYPE }}
+      - name: Test cminpack
+        run: ctest --test-dir ${{ env.CMINPACK_BUILD_DIR }} --build-config ${{ matrix.CMINPACK_BUILD_TYPE }}
+      - name: Install cminpack
+        run: cmake --install ${{ env.CMINPACK_BUILD_DIR }} --config ${{ matrix.CMINPACK_BUILD_TYPE }}
+      - name: Delete checkout directory
+        run: rm -rf $RUNNER_TEMP/cminpack
+      - name: Delete build directory
+        run: rm -rf ${{ env.CMINPACK_BUILD_DIR }}
+      - name: Delete install directory
+        run: rm -rf ${{ env.CMINPACK_INSTALL_DIR }}

--- a/.github/workflows/windows-visual-studio-cminpack-install.yaml
+++ b/.github/workflows/windows-visual-studio-cminpack-install.yaml
@@ -1,0 +1,41 @@
+name: MSVC - Install cminpack on Windows through CMake
+run-name: MSVC - Build, test and install cminpack on Windows through CMake
+on: [push]
+jobs:
+  cminpack-visual-studio:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: cmd
+    strategy:
+      matrix:
+        ARCH: [ 'x64', 'Win32']
+        CMINPACK_BUILD_SHARED_LIBS: [ 'ON' , 'OFF' ]
+        CMINPACK_BUILD_TYPE: [ 'Release', 'Debug', 'RelWithDebInfo', 'MinSizeRel' ]
+        CMINPACK_PRECISION: [ 'd' ] # seems to be the only precision that the current tests reference work
+    env:
+      CMINPACK_BUILD_DIR: >-
+        %RUNNER_TEMP%\cminpack-build-arch-${{ matrix.ARCH }}-shared-libs-${{ matrix.CMINPACK_BUILD_SHARED_LIBS }}-build-type-${{ matrix.CMINPACK_BUILD_TYPE }}-precision-${{ matrix.CMINPACK_PRECISION }}
+      CMINPACK_INSTALL_DIR: >-
+        %RUNNER_TEMP%\cminpack-install-arch-${{ matrix.ARCH }}-shared-libs-${{ matrix.CMINPACK_BUILD_SHARED_LIBS }}-build-type-${{ matrix.CMINPACK_BUILD_TYPE }}-precision-${{ matrix.CMINPACK_PRECISION }}
+    steps:
+      - name: Checkout sources with CRLF EOLs for reference test files
+        run: git config --global core.autocrlf true
+      - name: Checkout repository to cminpack directory
+        uses: actions/checkout@v4
+        with:
+          path: cminpack
+      - name: Configure cminpack build
+        run: cmake -DBUILD_SHARED_LIBS=${{ matrix.CMINPACK_BUILD_SHARED_LIBS }} -DCMAKE_BUILD_TYPE=${{ matrix.CMINPACK_BUILD_TYPE }} -DCMINPACK_PRECISION=${{ matrix.CMINPACK_PRECISION }} -DUSE_BLAS=OFF -A ${{ matrix.ARCH }} --install-prefix ${{ env.CMINPACK_INSTALL_DIR }} -S cminpack -B ${{ env.CMINPACK_BUILD_DIR }}
+      - name: Build cminpack
+        run: cmake --build ${{ env.CMINPACK_BUILD_DIR }} --config ${{ matrix.CMINPACK_BUILD_TYPE }}
+      - name: Test cminpack
+        run: ctest --test-dir ${{ env.CMINPACK_BUILD_DIR }} --build-config ${{ matrix.CMINPACK_BUILD_TYPE }}
+      - name: Install cminpack
+        run: cmake --install ${{ env.CMINPACK_BUILD_DIR }} --config ${{ matrix.CMINPACK_BUILD_TYPE }}
+      - name: Delete checkout directory
+        run: rmdir /S /Q cminpack
+      - name: Delete build directory
+        run: rmdir /S /Q ${{ env.CMINPACK_BUILD_DIR }}
+      - name: Delete install directory
+        run: rmdir /S /Q ${{ env.CMINPACK_INSTALL_DIR }}


### PR DESCRIPTION
## What?

I have added github actions to build, test, and install cminpack through CMake on the latest Ubuntu and Visual Studio github images.

## Why?

These additions are valuable to people learning and experimenting cminpack, and also for people working on cminpack forks to inspect and get a quick test response on their pushes.

## How?

* Added a file [.github/workflows/ubuntu-cminpack-install.yaml](.github/workflows/ubuntu-cminpack-install.yaml) to drive build + test + install through CMake on latest Ubuntu;
* Added a file [.github/workflows/windows-visual-studio-cminpack-install.yaml](.github/workflows/windows-visual-studio-cminpack-install.yaml) to build + test + install through CMake on latest Windows, employing the latest Visual Studio.

**Note 1**: Both workflows build + test + install on multiple conditions (shared libraries on/off, build types release/debug/relwithdebinfo/minsizerel) and Visual Studio also builds and tests on multiple architectures (x64 / Win32). However, since the reference tests only seem to work well with cminpack double precision version, it is the only precision used in the workflows.

## Testing?

1. The github action [.github/workflows/ubuntu-cminpack-install.yaml](.github/workflows/ubuntu-cminpack-install.yaml) works out of the box on latest Ubuntu
2. The github action [.github/workflows/windows-visual-studio-cminpack-install.yaml](.github/workflows/windows-visual-studio-cminpack-install.yaml) works out of the box on latest Windows + latest Visual Studio

**Note 2**: On a local virtual machine, I am able to build, test and install cminpack on Windows 11 through CMake with GCC + GNU Make provided by MSYS2. However, it is failing on a sketch workflow on github actions which I am still diagnosing the issue. It might come in the future if I manage to fix it. 