### PR TITLE
Added MSYS2 toolchains - gcc and clang - to appveyor CI builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,145 @@
 version: 1.0.{build}
 image:
-- Visual Studio 2015
+- Visual Studio 2022
 build:
   parallel: true
 environment:
   matrix:
-    - CMAKE_CONFIG_TYPE: "Release"
+    - job_name: MSVC toolchain
+      CMAKE_CONFIG_TYPE: "Release"
+      GENERATOR: Visual Studio 17 2022
+    
+    - job_name: MSYS2 x86_64 toolchain
+      CMAKE_CONFIG_TYPE: "Release"
+      SYS_MSYSTEM: 'MINGW64'
+      SYS_MENVIRONMENT: 'x86_64'
+      GENERATOR: MinGW Makefiles
+    
+    - job_name: MSYS2 UCRT64 toolchain
+      CMAKE_CONFIG_TYPE: "Release"
+      SYS_MSYSTEM: 'UCRT64'
+      SYS_MENVIRONMENT: 'ucrt-x86_64'
+      GENERATOR: MinGW Makefiles
+    
+    - job_name: MSYS2 CLANG64 toolchain
+      CMAKE_CONFIG_TYPE: "Release"
+      SYS_MSYSTEM: 'CLANG64'
+      SYS_MENVIRONMENT: 'clang-x86_64'
+      GENERATOR: MinGW Makefiles
 platform:
   - x64
-init:
+
+init: # Only MSVC toolchain will hit here
   # This is needed because reference files for tests must be checked-out with CRLF EOLs
   - git config --global core.autocrlf true
+
+for:
+  #
+  # init specific instructions for MSYS2 x86_64 toolchain
+  #
+  -
+    matrix:
+      only:
+        - job_name: MSYS2 x86_64 toolchain
+    
+    init:
+      # This is needed because reference files for tests must be checked-out with CRLF EOLs
+      - git config --global core.autocrlf true
+
+      #
+      # Following the guide on https://www.msys2.org/docs/ci#appveyor
+      # to build the project using MSYS2 toolchain on appveyor CI service
+      #
+      # Update MSYS2
+      - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu" # Core update (in case any core packages are outdated)
+      - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu" # Normal update
+      
+      # Setup MSYS2 environment
+      - set MSYSTEM=%SYS_MSYSTEM% # Start a 64 bit Mingw environment
+
+      # Install gcc on MSYS2
+      - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-%SYS_MENVIRONMENT%-gcc"
+      # Install GNU Make on MSYS2
+      - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-%SYS_MENVIRONMENT%-make"
+      
+      # Adjust system PATH environment variable
+      - set PATH=C:\msys64\%SYS_MSYSTEM%\bin;%PATH% # Place MSYS2 tools in front of system PATH
+
+  #
+  # init specific instructions for MSYS2 UCRT64 toolchain
+  #
+  -
+    matrix:
+      only:
+        - job_name: MSYS2 UCRT64 toolchain
+    
+    init:
+      # This is needed because reference files for tests must be checked-out with CRLF EOLs
+      - git config --global core.autocrlf true
+
+      #
+      # Following the guide on https://www.msys2.org/docs/ci#appveyor
+      # to build the project using MSYS2 toolchain on appveyor CI service
+      #
+      # Update MSYS2
+      - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu" # Core update (in case any core packages are outdated)
+      - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu" # Normal update
+      
+      # Setup MSYS2 environment
+      - set MSYSTEM=%SYS_MSYSTEM% # Start a 64 bit Mingw environment
+
+      # Install gcc on MSYS2
+      - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-%SYS_MENVIRONMENT%-gcc"
+      # Install GNU Make on MSYS2
+      - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-%SYS_MENVIRONMENT%-make"
+      
+      # Adjust system PATH environment variable
+      - set PATH=C:\msys64\%SYS_MSYSTEM%\bin;%PATH% # Place MSYS2 tools in front of system PATH
+
+  #
+  # init specific instructions for MSYS2 CLANG64 toolchain
+  #
+  -
+    matrix:
+      only:
+        - job_name: MSYS2 CLANG64 toolchain
+    
+    init:
+      # This is needed because reference files for tests must be checked-out with CRLF EOLs
+      - git config --global core.autocrlf true
+
+      #
+      # Following the guide on https://www.msys2.org/docs/ci#appveyor
+      # to build the project using MSYS2 toolchain on appveyor CI service
+      #
+      # Update MSYS2
+      - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu" # Core update (in case any core packages are outdated)
+      - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu" # Normal update
+      
+      # Setup MSYS2 environment
+      - set MSYSTEM=%SYS_MSYSTEM% # Start a 64 bit Mingw environment
+
+      # Install clang on MSYS2
+      - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-%SYS_MENVIRONMENT%-clang"
+      # Install GNU Make on MSYS2
+      - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-%SYS_MENVIRONMENT%-make"
+      
+      # Adjust system PATH environment variable
+      - set PATH=C:\msys64\%SYS_MSYSTEM%\bin;%PATH% # Place MSYS2 tools in front of system PATH
+
 build_script:
+  # Create build dir
   - mkdir build
+
+  # Change directory to build dir
   - cd build
-  - cmake -G "Visual Studio 14 2015 Win64" -DBUILD_SHARED_LIBS:BOOL=ON ..
+
+  # Configure to build the shared library
+  - cmake -G "%GENERATOR%" -DBUILD_SHARED_LIBS:BOOL=ON ..
+
+  # Perform the build
   - cmake --build . --config %CMAKE_CONFIG_TYPE%
 test_script:
-  - ctest --output-on-failure -C Release
+  
+  # Perform tests
+  - ctest --output-on-failure -C %CMAKE_CONFIG_TYPE%

--- a/examples/tchkder_.c
+++ b/examples/tchkder_.c
@@ -11,7 +11,7 @@ void fcn(const int *m, const int *n, const real *x, real *fvec,
 
 int main()
 {
-#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER < 1900))
+#if (defined(__MINGW32__) && !defined(_UCRT)) || (defined(_MSC_VER) && (_MSC_VER < 1900))
   _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
   int i, m, n, ldfjac, mode;

--- a/examples/tchkderc.c
+++ b/examples/tchkderc.c
@@ -21,7 +21,7 @@ int fcn(void *p, int m, int n, const real *x, real *fvec,
 
 int main()
 {
-#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER < 1900))
+#if (defined(__MINGW32__) && !defined(_UCRT)) || (defined(_MSC_VER) && (_MSC_VER < 1900))
   _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
   int i, ldfjac;

--- a/examples/tfdjac2_.c
+++ b/examples/tfdjac2_.c
@@ -14,7 +14,7 @@ void fcnjac(int m, int n, const real *x, real *fjac, int ldfjac);
 
 int main()
 {
-#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER < 1900))
+#if (defined(__MINGW32__) && !defined(_UCRT)) || (defined(_MSC_VER) && (_MSC_VER < 1900))
   _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
 

--- a/examples/tfdjac2c.c
+++ b/examples/tfdjac2c.c
@@ -19,7 +19,7 @@ void fcnjac(int m, int n, const real *x, real *fjac, int ldfjac);
 
 int main()
 {
-#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER < 1900))
+#if (defined(__MINGW32__) && !defined(_UCRT)) || (defined(_MSC_VER) && (_MSC_VER < 1900))
   _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
 

--- a/examples/thybrd1_.c
+++ b/examples/thybrd1_.c
@@ -11,7 +11,7 @@ void fcn(const int *n, const real *x, real *fvec, int *iflag);
 
 int main()
 {
-#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER < 1900))
+#if (defined(__MINGW32__) && !defined(_UCRT)) || (defined(_MSC_VER) && (_MSC_VER < 1900))
   _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
   int j, n, info, lwa;

--- a/examples/thybrd1c.c
+++ b/examples/thybrd1c.c
@@ -11,7 +11,7 @@ int fcn(void *p, int n, const real *x, real *fvec, int iflag);
 
 int main()
 {
-#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER < 1900))
+#if (defined(__MINGW32__) && !defined(_UCRT)) || (defined(_MSC_VER) && (_MSC_VER < 1900))
   _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
   int j, n, info, lwa;

--- a/examples/thybrd_.c
+++ b/examples/thybrd_.c
@@ -10,7 +10,7 @@ void fcn(const int *n, const real *x, real *fvec, int *iflag);
 
 int main()
 {
-#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER < 1900))
+#if (defined(__MINGW32__) && !defined(_UCRT)) || (defined(_MSC_VER) && (_MSC_VER < 1900))
   _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
   int j, n, maxfev, ml, mu, mode, nprint, info, nfev, ldfjac, lr;

--- a/examples/thybrdc.c
+++ b/examples/thybrdc.c
@@ -10,7 +10,7 @@ int fcn(void *p, int n, const real *x, real *fvec, int iflag);
 
 int main()
 {
-#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER < 1900))
+#if (defined(__MINGW32__) && !defined(_UCRT)) || (defined(_MSC_VER) && (_MSC_VER < 1900))
   _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
   int j, n, maxfev, ml, mu, mode, nprint, info, nfev, ldfjac, lr;

--- a/examples/thybrj1_.c
+++ b/examples/thybrj1_.c
@@ -16,7 +16,7 @@ int main()
   real x[9], fvec[9], fjac[9*9], wa[99];
   int one=1;
 
-#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER < 1900))
+#if (defined(__MINGW32__) && !defined(_UCRT)) || (defined(_MSC_VER) && (_MSC_VER < 1900))
   _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
 

--- a/examples/thybrj1c.c
+++ b/examples/thybrj1c.c
@@ -14,7 +14,7 @@ int main()
   int j, n, ldfjac, info, lwa;
   real tol, fnorm;
   real x[9], fvec[9], fjac[9*9], wa[99];
-#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER < 1900))
+#if (defined(__MINGW32__) && !defined(_UCRT)) || (defined(_MSC_VER) && (_MSC_VER < 1900))
   _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
   n = 9;

--- a/examples/thybrj_.c
+++ b/examples/thybrj_.c
@@ -11,7 +11,7 @@ void fcn(const int *n, const real *x, real *fvec, real *fjac, const int *ldfjac,
 
 int main()
 {
-#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER < 1900))
+#if (defined(__MINGW32__) && !defined(_UCRT)) || (defined(_MSC_VER) && (_MSC_VER < 1900))
   _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
   int j, n, ldfjac, maxfev, mode, nprint, info, nfev, njev, lr;

--- a/examples/thybrjc.c
+++ b/examples/thybrjc.c
@@ -18,7 +18,7 @@ int fcn(void *p, int n, const real *x, real *fvec, real *fjac, int ldfjac,
 
 int main()
 {
-#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER < 1900))
+#if (defined(__MINGW32__) && !defined(_UCRT)) || (defined(_MSC_VER) && (_MSC_VER < 1900))
   _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
 

--- a/examples/tlmdifc.c
+++ b/examples/tlmdifc.c
@@ -19,7 +19,7 @@ int fcn(void *p, int m, int n, const real *x, real *fvec, int iflag);
 
 int main()
 {
-#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER < 1900))
+#if (defined(__MINGW32__) && !defined(_UCRT)) || (defined(_MSC_VER) && (_MSC_VER < 1900))
   _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
   int i, j, maxfev, mode, nprint, info, nfev, ldfjac;


### PR DESCRIPTION
## What?

I have added new C toolchains -- *gcc and clang* -- provided by [MSYS2 project](https://www.msys2.org/)  to the Windows build on appveyor CI service.

## Why?

On Windows, the toolchains provided by [MSYS2 project](https://www.msys2.org/) are popular choices among programmers going for cross platform development. Therefore, since cminpack shares the same goal, it was a feature that I was looking to help with implementation.

## How?

- Changed the build image on [appveyor.yml](https://github.com/devernay/cminpack/compare/master...luau-project:cminpack:ci-appveyor-msys2?expand=1#diff-92ab9a36df5d8e9f7076f2fdec59492d1ac2d9cf27ea046767a7fc4d542ef3dc) to Visual Studio 2022 required by MSYS2 toolchains [https://www.msys2.org/docs/ci#appveyor](https://www.msys2.org/docs/ci#appveyor)
- I reworked the [appveyor.yml](https://github.com/devernay/cminpack/compare/master...luau-project:cminpack:ci-appveyor-msys2?expand=1#diff-92ab9a36df5d8e9f7076f2fdec59492d1ac2d9cf27ea046767a7fc4d542ef3dc) file to include x64 bit release builds for the following toolchains:
    - gcc x86_64;
    - gcc using the new universal C runtime for x64 bit (UCRT64);
    - clang for x64 bit (CLANG64).
- Added a preprocessor condition on test files ```&& !defined(_UCRT)``` to fix the build for gcc using the new universal C runtime for x64 bit (UCRT64).

## Testing?

The current [appveyor.yml](https://github.com/devernay/cminpack/compare/master...luau-project:cminpack:ci-appveyor-msys2?expand=1#diff-92ab9a36df5d8e9f7076f2fdec59492d1ac2d9cf27ea046767a7fc4d542ef3dc) file is building just fine on every toolchain (MSVC, gcc x86_64, gcc UCRT64 and clang64).

## Screenshots?

![Screenshot from 2024-04-03 14-23-48](https://github.com/devernay/cminpack/assets/18295115/4a44456b-6a03-4c0c-963b-5f783cacca74)