### PR TITLE
Fix CMake usage for freebsd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ foreach (cminpack_lib ${cminpack_libs})
     )
 
   if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-    target_link_libraries (${cminpack_lib} m)
+    target_link_libraries (${cminpack_lib} PUBLIC m)
   endif ()
 
   include (CheckLibraryExists)


### PR DESCRIPTION
CMake requires that `target_link_libraries` calls must either all use the `PUBLIC/PRIVATE` specifiers, or none use them. So update the FreeBSD-specific call to use the specifier like the rest of them.