### PR TITLE
improvement: BLAS support on all CI configurations on Github workflows

### DIFF
--- a/.github/workflows/msys2-cminpack-install.yaml
+++ b/.github/workflows/msys2-cminpack-install.yaml
@@ -13,67 +13,102 @@ jobs:
     
     strategy:
       matrix:
-        CMINPACK_BUILD_SHARED_LIBS: [ 'ON' , 'OFF' ]
-        CMINPACK_BUILD_TYPE: [ 'Release', 'Debug', 'RelWithDebInfo', 'MinSizeRel' ]
+        CMINPACK_BUILD_SHARED_LIBS: [ 'ON', 'OFF' ]
+        CMINPACK_BUILD_TYPE: [ 'Release', 'Debug' ]
         CMINPACK_PRECISION: [ 'd' ] # seems to be the only precision that the current tests reference work
+        USE_BLAS: ['OFF']
         MSYS2_CONFIG:
-              - { sys: mingw64, env: x86_64 }
-              - { sys: ucrt64, env: ucrt-x86_64 }
-              - { sys: clang64, env: clang-x86_64 }
-    
-    env:
-      CMINPACK_BUILD_DIR: >-
-        %RUNNER_TEMP%\cminpack-build-shared-libs-${{ matrix.CMINPACK_BUILD_SHARED_LIBS }}-build-type-${{ matrix.CMINPACK_BUILD_TYPE }}-precision-${{ matrix.CMINPACK_PRECISION }}
-      CMINPACK_INSTALL_DIR: >-
-        %RUNNER_TEMP%\cminpack-install-shared-libs-${{ matrix.CMINPACK_BUILD_SHARED_LIBS }}-build-type-${{ matrix.CMINPACK_BUILD_TYPE }}-precision-${{ matrix.CMINPACK_PRECISION }}
-    
-      MSYS2_PACKAGES_TO_INSTALL: "mingw-w64-${{ matrix.MSYS2_CONFIG.env }}-cc mingw-w64-${{ matrix.MSYS2_CONFIG.env }}-make"
+          - { sys: mingw64, env: x86_64 }
+          - { sys: ucrt64, env: ucrt-x86_64 }
+          - { sys: clang64, env: clang-x86_64 }
+        
+        include:
+          - CMINPACK_BUILD_SHARED_LIBS: 'ON'
+            CMINPACK_BUILD_TYPE: 'Release'
+            CMINPACK_PRECISION: 'd'
+            USE_BLAS: 'ON'
+            MSYS2_CONFIG: { sys: mingw64, env: x86_64 }
 
+          - CMINPACK_BUILD_SHARED_LIBS: 'ON'
+            CMINPACK_BUILD_TYPE: 'Release'
+            CMINPACK_PRECISION: 'd'
+            USE_BLAS: 'ON'
+            MSYS2_CONFIG: { sys: ucrt64, env: ucrt-x86_64 }
+          
+          - CMINPACK_BUILD_SHARED_LIBS: 'ON'
+            CMINPACK_BUILD_TYPE: 'Release'
+            CMINPACK_PRECISION: 'd'
+            USE_BLAS: 'ON'
+            MSYS2_CONFIG: { sys: clang64, env: clang-x86_64 }
+    
     steps:
       - name: Checkout repository to cminpack directory
         uses: actions/checkout@v4
         with:
           path: cminpack
+      
+      # Do not add spaces before '>>'
+      - name: Save an environment variable for the packages to install on MSYS2
+        run: |
+          if "${{ matrix.USE_BLAS }}" == "ON" (
+            echo MSYS2_PACKAGES_TO_INSTALL=mingw-w64-${{ matrix.MSYS2_CONFIG.env }}-cc mingw-w64-${{ matrix.MSYS2_CONFIG.env }}-make mingw-w64-${{ matrix.MSYS2_CONFIG.env }}-openblas>> ${{ github.env }}
+          ) else (
+            echo MSYS2_PACKAGES_TO_INSTALL=mingw-w64-${{ matrix.MSYS2_CONFIG.env }}-cc mingw-w64-${{ matrix.MSYS2_CONFIG.env }}-make>> ${{ github.env }}
+          )
 
       # Installing tools from MSYS2 could fail
       # on a high number of concurrent jobs.
-      # So, we keep retrying it for a few times
-      - name: Install C compiler + GNU Make from MSYS2
+      # So, in a PowerShell script, we keep retrying
+      # the installation for a few times.
+      - name: Install C compiler + GNU Make from MSYS2 + OpenBLAS (if USE_BLAS is ON)
         shell: pwsh
         run: |
-          $install_succeeded = $false;
+          $install_succeed = $false;
           $max_tries = 10;
           $tries = 0;
-          while ((-not $install_succeeded) -and ($tries -lt $max_tries))
+          while ((-not $install_succeed) -and ($tries -lt $max_tries))
           {
-            try
+            $output = C:\msys64\usr\bin\bash.exe -lc "pacman -S ${{ env.MSYS2_PACKAGES_TO_INSTALL }} --noconfirm" 2>&1
+
+            if ($LastExitCode -eq 0)
             {
-              & C:\msys64\usr\bin\bash.exe -lc "pacman -S ${{ env.MSYS2_PACKAGES_TO_INSTALL }} --noconfirm"
-              $install_succeeded = $true;
+              $install_succeed = $true;
             }
-            catch
+            else
             {
               $tries++;
             }
           }
 
-          if (-not $install_succeeded)
+          if (-not $install_succeed)
           {
             Write-Host "Failed to install MSYS2 packages: ${{ env.MSYS2_PACKAGES_TO_INSTALL }}";
-            exit 1;
+            exit /B 1;
           }
 
+      # Do not add spaces before '>>'
       - name: Place MSYS2 tools in front of system environment PATH variable
-        run: echo C:\msys64\${{ matrix.MSYS2_CONFIG.sys }}\bin;%PATH% >> %GITHUB_PATH%
+        run: echo C:\msys64\${{ matrix.MSYS2_CONFIG.sys }}\bin>> ${{ github.path }}
+
+      # Do not add spaces before '>>'
+      - name: Set environment variables to build cminpack
+        run: |
+          echo CMINPACK_BUILD_DIR=${{ runner.temp }}\cminpack-build>> ${{ github.env }}
+          echo CMINPACK_INSTALL_DIR=${{ runner.temp }}\cminpack-install>> ${{ github.env }}
 
       - name: Configure cminpack build
-        run: cmake -G "MinGW Makefiles" -DBUILD_SHARED_LIBS=${{ matrix.CMINPACK_BUILD_SHARED_LIBS }} -DCMAKE_BUILD_TYPE=${{ matrix.CMINPACK_BUILD_TYPE }} -DCMINPACK_PRECISION=${{ matrix.CMINPACK_PRECISION }} -DUSE_BLAS=OFF --install-prefix ${{ env.CMINPACK_INSTALL_DIR }} -S cminpack -B ${{ env.CMINPACK_BUILD_DIR }}
+        run: cmake -G "MinGW Makefiles" -DBUILD_SHARED_LIBS=${{ matrix.CMINPACK_BUILD_SHARED_LIBS }} -DCMAKE_BUILD_TYPE=${{ matrix.CMINPACK_BUILD_TYPE }} -DCMINPACK_PRECISION=${{ matrix.CMINPACK_PRECISION }} -DUSE_BLAS=${{ matrix.USE_BLAS }} --install-prefix ${{ env.CMINPACK_INSTALL_DIR }} -S cminpack -B ${{ env.CMINPACK_BUILD_DIR }}
       
       - name: Build cminpack
         run: cmake --build ${{ env.CMINPACK_BUILD_DIR }} --config ${{ matrix.CMINPACK_BUILD_TYPE }}
       
       - name: Test cminpack
+        if: ${{ matrix.USE_BLAS == 'OFF' }}
         run: ctest --test-dir ${{ env.CMINPACK_BUILD_DIR }} --build-config ${{ matrix.CMINPACK_BUILD_TYPE }}
+      
+      - name: Test cminpack with BLAS
+        if: ${{ matrix.USE_BLAS == 'ON' }}
+        run: ctest --test-dir ${{ env.CMINPACK_BUILD_DIR }} --build-config ${{ matrix.CMINPACK_BUILD_TYPE }} --exclude-regex tlmdifc
       
       - name: Install cminpack
         run: cmake --install ${{ env.CMINPACK_BUILD_DIR }} --config ${{ matrix.CMINPACK_BUILD_TYPE }}

--- a/.github/workflows/ubuntu-cminpack-install.yaml
+++ b/.github/workflows/ubuntu-cminpack-install.yaml
@@ -9,13 +9,14 @@ jobs:
 
     strategy:
       matrix:
-        BUILD_SHARED_LIBS: [ 'ON' , 'OFF' ]
-        CMAKE_BUILD_TYPE: [ 'Release', 'Debug', 'RelWithDebInfo', 'MinSizeRel' ]
+        BUILD_SHARED_LIBS: [ 'ON', 'OFF' ]
+        CMAKE_BUILD_TYPE: [ 'Release', 'Debug' ]
         CMINPACK_PRECISION: [ 'd' ] # seems to be the only precision that the current tests reference work
         USE_BLAS: [ 'OFF' ]
+        
         include:
           - BUILD_SHARED_LIBS: 'ON'
-            CMAKE_BUILD_TYPE: 'RelWithDebInfo'
+            CMAKE_BUILD_TYPE: 'Release'
             CMINPACK_PRECISION: 'd'
             USE_BLAS: 'ON'
     

--- a/.github/workflows/windows-visual-studio-cminpack-install.yaml
+++ b/.github/workflows/windows-visual-studio-cminpack-install.yaml
@@ -13,31 +13,83 @@ jobs:
     
     strategy:
       matrix:
-        ARCH: [ 'x64', 'Win32']
-        CMINPACK_BUILD_SHARED_LIBS: [ 'ON' , 'OFF' ]
-        CMINPACK_BUILD_TYPE: [ 'Release', 'Debug', 'RelWithDebInfo', 'MinSizeRel' ]
+        CMINPACK_BUILD_SHARED_LIBS: [ 'ON', 'OFF' ]
+        CMINPACK_BUILD_TYPE: [ 'Release', 'Debug' ]
         CMINPACK_PRECISION: [ 'd' ] # seems to be the only precision that the current tests reference work
-    
+        USE_BLAS: ['OFF']
+        
+        include:
+          - CMINPACK_BUILD_SHARED_LIBS: 'ON'
+            CMINPACK_BUILD_TYPE: 'Release'
+            CMINPACK_PRECISION: 'd'
+            USE_BLAS: 'ON'
+
     env:
-      CMINPACK_BUILD_DIR: >-
-        %RUNNER_TEMP%\cminpack-build-arch-${{ matrix.ARCH }}-shared-libs-${{ matrix.CMINPACK_BUILD_SHARED_LIBS }}-build-type-${{ matrix.CMINPACK_BUILD_TYPE }}-precision-${{ matrix.CMINPACK_PRECISION }}
-      CMINPACK_INSTALL_DIR: >-
-        %RUNNER_TEMP%\cminpack-install-arch-${{ matrix.ARCH }}-shared-libs-${{ matrix.CMINPACK_BUILD_SHARED_LIBS }}-build-type-${{ matrix.CMINPACK_BUILD_TYPE }}-precision-${{ matrix.CMINPACK_PRECISION }}
-    
+
+      BLAS_VERSION: "0.3.27"
+
     steps:
+
+      - name: Download and extract BLAS source code
+        if: ${{ matrix.USE_BLAS == 'ON' }}
+        run: |
+          C:\msys64\usr\bin\wget https://github.com/OpenMathLib/OpenBLAS/archive/refs/tags/v${{ env.BLAS_VERSION }}.zip -P ${{ runner.temp }}
+          "C:\Program Files\7-Zip\7z.exe" x ${{ runner.temp }}\v${{ env.BLAS_VERSION }}.zip -o${{ runner.temp }}
+      
+      # Do not add spaces before '>>'
+      - name: Set environment variables to build and install BLAS
+        if: ${{ matrix.USE_BLAS == 'ON' }}
+        run: |
+          echo BLAS_SOURCE_DIR=${{ runner.temp }}\OpenBLAS-${{ env.BLAS_VERSION }}>> ${{ github.env }}
+          echo BLAS_BUILD_DIR=${{ runner.temp }}\build-OpenBLAS-${{ env.BLAS_VERSION }}>> ${{ github.env }}
+          echo BLAS_INSTALL_DIR=${{ runner.temp }}\install-OpenBLAS-${{ env.BLAS_VERSION }}>> ${{ github.env }}
+
+      - name: Configure BLAS
+        if: ${{ matrix.USE_BLAS == 'ON' }}
+        run: cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF --install-prefix ${{ env.BLAS_INSTALL_DIR }} -S ${{ env.BLAS_SOURCE_DIR }} -B ${{ env.BLAS_BUILD_DIR }}
+
+      - name: Build BLAS
+        if: ${{ matrix.USE_BLAS == 'ON' }}
+        run: cmake --build ${{ env.BLAS_BUILD_DIR }} --config Release
+
+      - name: Install BLAS
+        if: ${{ matrix.USE_BLAS == 'ON' }}
+        run: cmake --install ${{ env.BLAS_BUILD_DIR }} --config Release
+
+      # Do not add spaces before '>>'
+      - name: Set CMAKE_PREFIX_PATH environment variable to BLAS be found by CMake
+        if: ${{ matrix.USE_BLAS == 'ON' }}
+        run: echo CMAKE_PREFIX_PATH=${{ env.BLAS_INSTALL_DIR }}>> ${{ github.env }}
+      
+      # Do not add spaces before '>>'
+      - name: Place BLAS bin directory (containing BLAS dll) on system PATH environment variable to run tests
+        if: ${{ matrix.USE_BLAS == 'ON' }}
+        run: echo ${{ env.BLAS_INSTALL_DIR }}\bin>> ${{ github.path }}
+
       - name: Checkout repository to cminpack directory
         uses: actions/checkout@v4
         with:
           path: cminpack
       
+      # Do not add spaces before '>>'
+      - name: Set environment variables to build cminpack
+        run: |
+          echo CMINPACK_BUILD_DIR=${{ runner.temp }}\cminpack-build>> ${{ github.env }}
+          echo CMINPACK_INSTALL_DIR=${{ runner.temp }}\cminpack-install>> ${{ github.env }}
+
       - name: Configure cminpack build
-        run: cmake -DBUILD_SHARED_LIBS=${{ matrix.CMINPACK_BUILD_SHARED_LIBS }} -DCMAKE_BUILD_TYPE=${{ matrix.CMINPACK_BUILD_TYPE }} -DCMINPACK_PRECISION=${{ matrix.CMINPACK_PRECISION }} -DUSE_BLAS=OFF -A ${{ matrix.ARCH }} --install-prefix ${{ env.CMINPACK_INSTALL_DIR }} -S cminpack -B ${{ env.CMINPACK_BUILD_DIR }}
+        run: cmake -DBUILD_SHARED_LIBS=${{ matrix.CMINPACK_BUILD_SHARED_LIBS }} -DCMAKE_BUILD_TYPE=${{ matrix.CMINPACK_BUILD_TYPE }} -DCMINPACK_PRECISION=${{ matrix.CMINPACK_PRECISION }} -DUSE_BLAS=${{ matrix.USE_BLAS }} --install-prefix ${{ env.CMINPACK_INSTALL_DIR }} -S cminpack -B ${{ env.CMINPACK_BUILD_DIR }}
       
       - name: Build cminpack
         run: cmake --build ${{ env.CMINPACK_BUILD_DIR }} --config ${{ matrix.CMINPACK_BUILD_TYPE }}
       
       - name: Test cminpack
+        if: ${{ matrix.USE_BLAS == 'OFF' }}
         run: ctest --test-dir ${{ env.CMINPACK_BUILD_DIR }} --build-config ${{ matrix.CMINPACK_BUILD_TYPE }}
+      
+      - name: Test cminpack with BLAS
+        if: ${{ matrix.USE_BLAS == 'ON' }}
+        run: ctest --test-dir ${{ env.CMINPACK_BUILD_DIR }} --build-config ${{ matrix.CMINPACK_BUILD_TYPE }} --exclude-regex tlmdifc
       
       - name: Install cminpack
         run: cmake --install ${{ env.CMINPACK_BUILD_DIR }} --config ${{ matrix.CMINPACK_BUILD_TYPE }}


### PR DESCRIPTION
## What?

I have improved BLAS building/testing on all supported CI configurations on Github workflows (Ubuntu, MSYS2, MSVC).

## Why?

It eases the process to check if future changes to the code is somewhat damaging the current state for BLAS support.

## How?

* On Ubuntu, I simplified the building/testing with BLAS by installing the library ```libblas-dev```;
* On MSYS2, there are builtin packages named ```mingw-w64-x86_64-blas```, ```mingw-w64-ucrt-x86_64-blas``` and ```mingw-w64-clang-x86_64-blas``` for every MSYS2 environment (```mingw64```, ```ucrt64```, ```clang64```), respectively. So, I'm just installing it and building/testing against it;
* On MSVC, the most challenging changes, I had to do a major rework to support BLAS:
   1. First, since BLAS is a Fortran library, and there's not a "simple" manner to install a Fortran compiler which generates MSVC ABI-compatible binaries, I had to install LLVM flang-new [https://flang.llvm.org/docs/](https://flang.llvm.org/docs/) Fortran compiler from ```conda-forge``` channel using miniconda [https://docs.anaconda.com/miniconda/](https://docs.anaconda.com/miniconda/);
   2. Then I download BLAS from its repository [https://github.com/Reference-LAPACK/lapack](https://github.com/Reference-LAPACK/lapack) and build the library with ```LLVM flang-new```;
   3. Then I'm uploading the built BLAS library as artifact;
   4. All these steps from (i) to (iii) were done in a separate job, called ```build-BLAS```;
   5. The main cminpack testing job (```cminpack-visual-studio```) downloads the built BLAS library from the  ```build-BLAS``` job execution and performs the building / testing of cminpack.

> [!NOTE]
> 
> In the MSVC CI rework, I had to remove the building/testing of x86 binaries.